### PR TITLE
Made lyrics center vertically during playing

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screen/LyricsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screen/LyricsScreen.kt
@@ -89,7 +89,6 @@ fun LyricsScreen(
 	val currentDuration = duration * progressState.toDouble()
 
 	val density = LocalDensity.current
-	val rowHeightPx = with(density) { 64.dp.toPx() }.toInt()
 	val listState = rememberLazyListState()
 
 	AnimatedContent(


### PR DESCRIPTION
Improved the lyrics screen by making the active line scroll smoothly to the center instead being left behind.