### PR TITLE
upload ci artifacts to discord webhook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
 
   upload-artifacts-to-discord:
     name: Upload Artifacts to Discord
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [build-apk, build-ipa]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<img width="746" height="349" alt="image" src="https://github.com/user-attachments/assets/d45aeac4-59a9-4c76-95fb-feed2dcdccc9" />

(ignore that the files are 4 bytes I did that so I don't have to wait 3 years for build)