### PR TITLE
feat: clicking the title in PlayerScreen opens its TracksScreen (album)

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screen/PlayerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screen/PlayerScreen.kt
@@ -261,6 +261,22 @@ fun PlayerScreen(
 				track?.title?.let { title ->
 					MarqueeText(
 						title,
+						modifier = Modifier.clickable(enabled) {
+							track.albumId?.let {
+								backStack.removeLastOrNull()
+
+								val lastScreen = backStack.lastOrNull()
+
+								val isSameAlbum = if (lastScreen is Screen.Tracks) {
+									lastScreen.partialCollection.id == track.albumId
+								} else {
+									false
+								}
+
+								if (!isSameAlbum)
+									backStack.add(Screen.Tracks(playerState.tracks ?: return@clickable))
+							}
+						},
 						style = LocalTextStyle.current
 							.copy(shadow = textShadow),
 					)


### PR DESCRIPTION
This is a really small modification that allows to access the current listened track's album from the Player. 

It is kinda useful for example for people that play a song from a album, continue navigating the app and want to go back to the album without having to de-navigate the whole app again.