### PR TITLE
fix(SettingSwitchRow): make dividers false by default

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/dialogs/ShareDialog.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/dialogs/ShareDialog.kt
@@ -150,8 +150,7 @@ fun ShareDialog(
 					onSetValue = {
 						onExpiryChange(if (it) 1.hours else null)
 					},
-					contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp),
-					isDividerShown = false
+					contentPadding = PaddingValues(horizontal = 14.dp, vertical = 10.dp)
 				)
 				expiry?.let {
 					FormRow {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/settings/SettingSwitchRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/settings/SettingSwitchRow.kt
@@ -22,7 +22,7 @@ fun SettingSwitchRow(
 	onSetValue: (Boolean) -> Unit,
 	enabled: Boolean = true,
 	contentPadding: PaddingValues = PaddingValues(horizontal = 14.dp, vertical = 18.dp),
-	isDividerShown: Boolean = true
+	isDividerShown: Boolean = false
 ) {
 	FormRow(
 		onClick = { onSetValue(!value) },


### PR DESCRIPTION
this makes the dividers on most switches optional (false by default), it kind of looks like the switches have subitems... 