### PR TITLE
Unable to Add Music to Playlist bug fixed

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/CustomDialog.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/CustomDialog.kt
@@ -63,7 +63,7 @@ fun CustomDialog(
 
 			Row(
 				modifier = Modifier.fillMaxWidth(),
-				horizontalArrangement = Arrangement.End,
+				horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
 				verticalAlignment = Alignment.CenterVertically
 			) {
 				buttons()


### PR DESCRIPTION
The Buttons section in CustomDialog Collapsed and not shown When Content Get All Of Dialog Height   I Add Some Spacer and some modifiers for preventing this bug 
you can generate this bug in AddToPlaylistsScreen when number of playlists goes beyond 10 or 12 and because of this bug user can not add song to any playlist 