### PR TITLE
fix(AlbumsScreen): set fadeInSpec to null

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/ArtGrid.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/ArtGrid.kt
@@ -168,7 +168,7 @@ fun LazyGridScope.artGridError(
 ) {
 	item(span = { GridItemSpan(maxLineSpan) }) {
 		ErrorBox(
-			modifier = Modifier.animateItem(),
+			modifier = Modifier.animateItem(fadeInSpec = null),
 			error = state
 		)
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/AlbumsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/AlbumsScreen.kt
@@ -96,7 +96,7 @@ fun AlbumsScreen(
 			SortButton(!nested, viewModel)
 		}
 	}
-	val isLoggedIn = SessionManager.isLoggedIn.collectAsState()
+	val isLoggedIn by SessionManager.isLoggedIn.collectAsState()
 
 	Scaffold(
 		topBar = {
@@ -123,7 +123,7 @@ fun AlbumsScreen(
 			isRefreshing = isRefreshing || albumsState is UiState.Loading,
 			onRefresh = { viewModel.refreshAlbums() }
 		) {
-			if (!isLoggedIn.value) {
+			if (!isLoggedIn) {
 				Text(
 					stringResource(Res.string.info_needs_log_in),
 					color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -145,7 +145,7 @@ fun AlbumsScreen(
 						is UiState.Success -> {
 							items(state.data, { it.id }) { album ->
 								AlbumsScreenItem(
-									modifier = Modifier.animateItem(),
+									modifier = Modifier.animateItem(fadeInSpec = null),
 									album = album,
 									viewModel = viewModel,
 									tab = "albums",

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/LibraryScreen.kt
@@ -177,7 +177,7 @@ fun LibraryScreen(
 						seeAll = true
 					) { album ->
 						AlbumsScreenItem(
-							modifier = Modifier.animateItem().width(150.dp),
+							modifier = Modifier.animateItem(fadeInSpec = null).width(150.dp),
 							album = album,
 							viewModel = albumsViewModel,
 							onSetShareId = { shareId = it },
@@ -192,7 +192,7 @@ fun LibraryScreen(
 						seeAll = true
 					) { playlist ->
 						PlaylistsScreenItem(
-							modifier = Modifier.animateItem().width(150.dp),
+							modifier = Modifier.animateItem(fadeInSpec = null).width(150.dp),
 							playlist = playlist,
 							viewModel = playlistsViewModel,
 							onSetShareId = { shareId = it },
@@ -209,7 +209,7 @@ fun LibraryScreen(
 						seeAll = true
 					) { artist ->
 						ArtistsScreenItem(
-							modifier = Modifier.animateItem().width(150.dp),
+							modifier = Modifier.animateItem(fadeInSpec = null).width(150.dp),
 							artist = artist,
 							viewModel = artistsViewModel,
 							tab = "library"

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/PlaylistsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/PlaylistsScreen.kt
@@ -187,7 +187,7 @@ fun PlaylistsScreen(
 						is UiState.Success -> {
 							items(state.data, { it.id }) { playlist ->
 								PlaylistsScreenItem(
-									modifier = Modifier.animateItem(),
+									modifier = Modifier.animateItem(fadeInSpec = null),
 									playlist = playlist,
 									tab = "playlists",
 									viewModel = viewModel,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/SearchScreen.kt
@@ -217,7 +217,7 @@ fun SearchScreen(
 								seeAll = false
 							) { album ->
 								AlbumsScreenItem(
-									modifier = Modifier.animateItem().width(150.dp),
+									modifier = Modifier.animateItem(fadeInSpec = null).width(150.dp),
 									album = album,
 									viewModel = albumsViewModel,
 									onSetShareId = { },
@@ -233,7 +233,7 @@ fun SearchScreen(
 								seeAll = false
 							) { artist ->
 								ArtistsScreenItem(
-									modifier = Modifier.animateItem().width(150.dp),
+									modifier = Modifier.animateItem(fadeInSpec = null).width(150.dp),
 									artist = artist,
 									viewModel = artistsViewModel,
 									tab = "search"

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/SharesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/SharesScreen.kt
@@ -118,7 +118,7 @@ fun SharesScreen(
 						is UiState.Success -> {
 							items(state.data, { it.id }) { share ->
 								SharesScreenItem(
-									modifier = Modifier.animateItem(),
+									modifier = Modifier.animateItem(fadeInSpec = null),
 									share = share,
 									onSetDeletionId = { newDeletionId ->
 										deletionId = newDeletionId


### PR DESCRIPTION
this sets fadeInSpec of the animateItem modifier to null so the albums page (and also any related ones) can actually load and not require scrolling or randomly tapping on something (oh and this also adjusts the isLoggedIn variable)