### PR TITLE
fix: restart scrobble tracker on media change

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/shared/ScrobbleManager.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/shared/ScrobbleManager.kt
@@ -31,6 +31,7 @@ class ScrobbleManager(
 		accumulatedPlayTime = 0
 
 		progressJob?.cancel()
+		startProgressTracker()
 
 		scrobbleNowPlaying(mediaId)
 	}


### PR DESCRIPTION
`onPlayStateChanged` sometimes doesn't get called when the next track plays without interruption, so the progress tracker never restarts for the next track.

Fixes #182 (should)