### PR TITLE
fix: flag password input as password input

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/login/pages/Fields.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/login/pages/Fields.kt
@@ -118,7 +118,8 @@ fun LoginScreenFields(
 		label = { Text(stringResource(Res.string.option_account_password)) },
 		enabled = !isBusy,
 		keyboardOptions = KeyboardOptions(
-			autoCorrectEnabled = false
+			autoCorrectEnabled = false,
+			keyboardType = KeyboardType.Password,
 		)
 	)
 }


### PR DESCRIPTION
Flags the password input to use the correct keyboard type.

In most modern keyboards, this will suggest to the keyboard to enable private/secure input, which typically prevents the keyboard from input-based customisation. In GBoard, for example, this will prevent it from learning from the input and suggesting it again at a later time. This is a basic security expectation. This is separate from the "don't use autocomplete" flag currently enabled, which only prevents autocomplete in that field.

I have not tested this change as I don't have an environment to do so.