### PR TITLE
Artist page improvements

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/CoverArt.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/CoverArt.kt
@@ -1,5 +1,6 @@
 package paige.navic.ui.components.common
 
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.indication
@@ -48,6 +49,7 @@ fun CoverArt(
 	coverArtId: String?,
 	contentDescription: String? = null,
 	onClick: (() -> Unit)? = null,
+	onLongClick: (() -> Unit)? = null,
 	enabled: Boolean = false,
 	square: Boolean = true,
 	crossfadeMs: Int = 500,
@@ -82,9 +84,10 @@ fun CoverArt(
 			.then(
 				if (enabled) {
 					if (onClick != null) {
-						Modifier.clickable(
+						Modifier.combinedClickable(
 							interactionSource = interactionSource,
-							onClick = onClick
+							onClick = onClick,
+							onLongClick = onLongClick
 						)
 					} else {
 						Modifier.clickable(interactionSource = interactionSource) {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousRoundedRectangle
 import navic.composeapp.generated.resources.Res
@@ -43,6 +42,7 @@ import paige.navic.icons.outlined.Check
 import paige.navic.icons.outlined.DownloadOff
 import paige.navic.icons.outlined.Offline
 import paige.navic.shared.MediaPlayerViewModel
+import paige.navic.ui.components.common.MarqueeText
 import paige.navic.ui.components.dialogs.QueueDuplicateDialog
 import paige.navic.ui.components.sheets.SongSheet
 import paige.navic.ui.screens.playlist.dialogs.PlaylistUpdateDialog
@@ -60,7 +60,7 @@ fun SongRow(
 	onRemoveStar: () -> Unit,
 	onAddStar: () -> Unit,
 	onShare: () -> Unit,
-	starredState: UiState<Boolean>,
+	starredState: Boolean,
 	download: DownloadEntity? = null,
 	onDownload: () -> Unit,
 	onCancelDownload: () -> Unit,
@@ -82,7 +82,7 @@ fun SongRow(
 
 	ListItem(
 		modifier = modifier
-			.width((LocalConfiguration.current.screenWidthDp * 0.875f).dp)
+			.width(350.dp)
 			.combinedClickable (
 				onClick = onClick,
 				onLongClick = onLongClick
@@ -91,15 +91,14 @@ fun SongRow(
 			Text(song.title)
 		},
 		supportingContent = {
-			Text(
-				buildString {
+			MarqueeText(
+				text = buildString {
 					append(song.albumTitle ?: stringResource(Res.string.info_unknown_album))
 					append(" • ")
 					append(song.artistName)
 					append(" • ")
 					append(song.year ?: stringResource(Res.string.info_unknown_year))
-				},
-				maxLines = 2
+				}
 			)
 		},
 		leadingContent = {
@@ -167,7 +166,7 @@ fun SongRow(
 		SongSheet(
 			onDismissRequest = onDismissRequest,
 			song = song,
-			starred = (starredState as? UiState.Success)?.data,
+			starred = starredState,
 			onSetStarred = { starred ->
 				if (starred) onAddStar() else onRemoveStar()
 			},

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
@@ -2,11 +2,11 @@ package paige.navic.ui.components.common
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -22,13 +22,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousRoundedRectangle
+import kotlinx.collections.immutable.persistentListOf
 import navic.composeapp.generated.resources.Res
-import navic.composeapp.generated.resources.info_unknown_album
-import navic.composeapp.generated.resources.info_unknown_year
 import navic.composeapp.generated.resources.info_download_failed
 import navic.composeapp.generated.resources.info_downloaded
 import navic.composeapp.generated.resources.info_not_available_offline
-import kotlinx.collections.immutable.persistentListOf
+import navic.composeapp.generated.resources.info_unknown_album
+import navic.composeapp.generated.resources.info_unknown_year
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalNavStack
@@ -42,11 +42,9 @@ import paige.navic.icons.outlined.Check
 import paige.navic.icons.outlined.DownloadOff
 import paige.navic.icons.outlined.Offline
 import paige.navic.shared.MediaPlayerViewModel
-import paige.navic.ui.components.common.MarqueeText
 import paige.navic.ui.components.dialogs.QueueDuplicateDialog
 import paige.navic.ui.components.sheets.SongSheet
 import paige.navic.ui.screens.playlist.dialogs.PlaylistUpdateDialog
-import paige.navic.utils.UiState
 
 @Composable
 fun SongRow(
@@ -67,6 +65,8 @@ fun SongRow(
 	onDeleteDownload: () -> Unit,
 	onPlayNext: () -> Unit,
 	onAddToQueue: () -> Unit,
+	rating: Int,
+	onSetRating: (Int) -> Unit
 ) {
 	val player = koinViewModel<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
@@ -167,6 +167,7 @@ fun SongRow(
 			onDismissRequest = onDismissRequest,
 			song = song,
 			starred = starredState,
+			rating = rating,
 			onSetStarred = { starred ->
 				if (starred) onAddStar() else onRemoveStar()
 			},
@@ -205,7 +206,8 @@ fun SongRow(
 			isOnline = isOnline,
 			onDownload = onDownload,
 			onCancelDownload = onCancelDownload,
-			onDeleteDownload = onDeleteDownload
+			onDeleteDownload = onDeleteDownload,
+			onSetRating = onSetRating
 		)
 	}
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.CircularProgressIndicator
@@ -19,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousRoundedRectangle
 import navic.composeapp.generated.resources.Res
@@ -79,10 +81,12 @@ fun SongRow(
 	val canPlay = isOnline || isDownloaded
 
 	ListItem(
-		modifier = modifier.combinedClickable (
-			onClick = onClick,
-			onLongClick = onLongClick
-		),
+		modifier = modifier
+			.width((LocalConfiguration.current.screenWidthDp * 0.875f).dp)
+			.combinedClickable (
+				onClick = onClick,
+				onLongClick = onLongClick
+			),
 		headlineContent = {
 			Text(song.title)
 		},
@@ -95,7 +99,7 @@ fun SongRow(
 					append(" • ")
 					append(song.year ?: stringResource(Res.string.info_unknown_year))
 				},
-				maxLines = 1
+				maxLines = 2
 			)
 		},
 		leadingContent = {
@@ -106,7 +110,7 @@ fun SongRow(
 			)
 		},
 		trailingContent = {
-			Row(verticalAlignment = Alignment.CenterVertically) {
+			Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.height(83.dp)) {
 				if (!canPlay) {
 					Icon(
 						Icons.Outlined.Offline,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
@@ -1,37 +1,88 @@
 package paige.navic.ui.components.common
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousRoundedRectangle
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.info_unknown_album
 import navic.composeapp.generated.resources.info_unknown_year
+import navic.composeapp.generated.resources.info_download_failed
+import navic.composeapp.generated.resources.info_downloaded
+import navic.composeapp.generated.resources.info_not_available_offline
+import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
-import paige.navic.LocalCtx
+import paige.navic.LocalNavStack
+import paige.navic.data.database.entities.DownloadEntity
+import paige.navic.data.database.entities.DownloadStatus
+import paige.navic.data.models.Screen
 import paige.navic.data.models.settings.Settings
 import paige.navic.domain.models.DomainSong
+import paige.navic.icons.Icons
+import paige.navic.icons.outlined.Check
+import paige.navic.icons.outlined.DownloadOff
+import paige.navic.icons.outlined.Offline
 import paige.navic.shared.MediaPlayerViewModel
+import paige.navic.ui.components.dialogs.QueueDuplicateDialog
+import paige.navic.ui.components.sheets.SongSheet
+import paige.navic.ui.screens.playlist.dialogs.PlaylistUpdateDialog
+import paige.navic.utils.UiState
 
 @Composable
 fun SongRow(
 	modifier: Modifier = Modifier,
-	song: DomainSong
+	song: DomainSong,
+	selected: Boolean = false,
+	onClick: (() -> Unit),
+	onLongClick: (() -> Unit),
+	isOnline: Boolean = false,
+	onDismissRequest: () -> Unit,
+	onRemoveStar: () -> Unit,
+	onAddStar: () -> Unit,
+	onShare: () -> Unit,
+	starredState: UiState<Boolean>,
+	download: DownloadEntity? = null,
+	onDownload: () -> Unit,
+	onCancelDownload: () -> Unit,
+	onDeleteDownload: () -> Unit,
+	onPlayNext: () -> Unit,
+	onAddToQueue: () -> Unit,
 ) {
-	val ctx = LocalCtx.current
 	val player = koinViewModel<MediaPlayerViewModel>()
+	val playerState by player.uiState.collectAsStateWithLifecycle()
+
+	val backStack = LocalNavStack.current
+	var playlistDialogShown by rememberSaveable { mutableStateOf(false) }
+	var duplicateQueueDialogShown by rememberSaveable { mutableStateOf(false) }
+	var duplicateQueueDialogShownPlayNext by rememberSaveable { mutableStateOf(false) }
+
+	val isDownloaded = download?.status == DownloadStatus.DOWNLOADED
+	val isCurrentTrack = playerState.currentSong?.id == song.id
+	val canPlay = isOnline || isDownloaded
+
 	ListItem(
-		modifier = modifier.clickable {
-			ctx.clickSound()
-			player.clearQueue()
-			player.addToQueueSingle(song)
-			player.playAt(0)
-		},
+		modifier = modifier.combinedClickable (
+			onClick = onClick,
+			onLongClick = onLongClick
+		),
 		headlineContent = {
 			Text(song.title)
 		},
@@ -53,6 +104,125 @@ fun SongRow(
 				modifier = Modifier.size(50.dp),
 				shape = ContinuousRoundedRectangle((Settings.shared.artGridRounding / 1.75f).dp)
 			)
+		},
+		trailingContent = {
+			Row(verticalAlignment = Alignment.CenterVertically) {
+				if (!canPlay) {
+					Icon(
+						Icons.Outlined.Offline,
+						stringResource(Res.string.info_not_available_offline),
+						modifier = Modifier.size(20.dp)
+					)
+					Spacer(Modifier.width(6.dp))
+				}
+				if (download != null && !isCurrentTrack) {
+					when (download.status) {
+						DownloadStatus.DOWNLOADING -> {
+							CircularProgressIndicator(
+								progress = { download.progress },
+								modifier = Modifier.size(16.dp),
+								strokeWidth = 2.dp
+							)
+							Spacer(Modifier.width(8.dp))
+						}
+
+						DownloadStatus.DOWNLOADED -> {
+							Icon(
+								Icons.Outlined.Check,
+								contentDescription = stringResource(Res.string.info_downloaded),
+								modifier = Modifier.size(16.dp),
+								tint = MaterialTheme.colorScheme.primary
+							)
+							Spacer(Modifier.width(8.dp))
+						}
+
+						DownloadStatus.FAILED -> {
+							Icon(
+								Icons.Outlined.DownloadOff,
+								contentDescription = stringResource(Res.string.info_download_failed),
+								modifier = Modifier.size(16.dp),
+								tint = MaterialTheme.colorScheme.error
+							)
+							Spacer(Modifier.width(8.dp))
+						}
+
+						else -> {}
+					}
+				}
+				if (isCurrentTrack) {
+					Waveform(
+						modifier = Modifier.padding(end = 12.dp),
+						isPlaying = !playerState.isPaused
+					)
+				}
+			}
 		}
 	)
+
+	if (selected) {
+		SongSheet(
+			onDismissRequest = onDismissRequest,
+			song = song,
+			starred = (starredState as? UiState.Success)?.data,
+			onSetStarred = { starred ->
+				if (starred) onAddStar() else onRemoveStar()
+			},
+			onShare = onShare,
+			onPlayNext = {
+				if (player.uiState.value.queue.any { it.id == song.id }) {
+					duplicateQueueDialogShown = true
+					duplicateQueueDialogShownPlayNext = true
+				} else {
+					onPlayNext()
+				}
+			},
+			onAddToQueue = {
+				if (player.uiState.value.queue.any { it.id == song.id }) {
+					duplicateQueueDialogShown = true
+					duplicateQueueDialogShownPlayNext = false
+				} else {
+					onAddToQueue()
+				}
+			},
+			onTrackInfo = {
+				backStack.add(Screen.SongDetail(song.id))
+			},
+			onViewAlbum = {
+				backStack.add(
+					Screen.CollectionDetail(
+						collectionId = song.albumId as String,
+						tab = "library"
+					)
+				)
+			},
+			onAddToPlaylist = {
+				playlistDialogShown = true
+			},
+			downloadStatus = download?.status,
+			isOnline = isOnline,
+			onDownload = onDownload,
+			onCancelDownload = onCancelDownload,
+			onDeleteDownload = onDeleteDownload
+		)
+	}
+
+	if (playlistDialogShown) {
+		@Suppress("AssignedValueIsNeverRead")
+		PlaylistUpdateDialog(
+			songs = persistentListOf(song),
+			onDismissRequest = { playlistDialogShown = false }
+		)
+	}
+
+	if (duplicateQueueDialogShown) {
+		QueueDuplicateDialog(
+			onDismissRequest = {
+				duplicateQueueDialogShown = false
+				onDismissRequest()
+			},
+			onConfirm = {
+				if (duplicateQueueDialogShownPlayNext) onPlayNext() else onAddToQueue()
+			}
+		)
+	}
 }

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/ArtCarousel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/ArtCarousel.kt
@@ -64,6 +64,7 @@ fun CarouselItemScope.ArtCarouselItem(
 	coverArtId: String?,
 	title: String,
 	contentDescription: String?,
+	onSelect: () -> Unit = {},
 	onClick: () -> Unit = {}
 ) {
 	val ctx = LocalCtx.current
@@ -85,6 +86,7 @@ fun CarouselItemScope.ArtCarouselItem(
 				focusManager.clearFocus(true)
 				onClick()
 			},
+			onLongClick = onSelect,
 			enabled = true
 		)
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ContainedLoadingIndicator
@@ -49,6 +50,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import navic.composeapp.generated.resources.Res
@@ -70,6 +72,8 @@ import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.data.models.Screen
 import paige.navic.data.models.settings.Settings
 import paige.navic.data.models.settings.enums.BottomBarVisibilityMode
+import paige.navic.domain.models.DomainSong
+import paige.navic.domain.models.DomainSongCollection
 import paige.navic.managers.DownloadManager
 import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.ui.components.common.ErrorBox
@@ -83,9 +87,11 @@ import paige.navic.ui.screens.artist.components.ArtistActionButtons
 import paige.navic.ui.screens.artist.components.ArtistDetailScreenHeading
 import paige.navic.ui.screens.artist.components.ArtistDetailScreenTopBar
 import paige.navic.ui.screens.artist.viewmodels.ArtistDetailViewModel
+import paige.navic.ui.screens.share.dialogs.ShareDialog
 import paige.navic.utils.LocalBottomBarScrollManager
 import paige.navic.utils.UiState
 import paige.navic.utils.fadeFromTop
+import kotlin.time.Duration
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -98,12 +104,18 @@ fun ArtistDetailScreen(
 	)
 	val ctx = LocalCtx.current
 	val player = koinViewModel<MediaPlayerViewModel>()
+	val playerState by player.uiState.collectAsStateWithLifecycle()
+
+	val selection by viewModel.selectedSong.collectAsState()
+
 	val downloadManager = koinInject<DownloadManager>()
 	val density = LocalDensity.current
 	val backStack = LocalNavStack.current
 	val layoutDirection = LocalLayoutDirection.current
 	val artistState by viewModel.artistState.collectAsState()
 	val isOnline by viewModel.isOnline.collectAsState()
+	val allDownloads by viewModel.allDownloads.collectAsState()
+	val starredState by viewModel.starredState.collectAsState()
 	val downloadStatus by viewModel.collectionDownloadStatus()
 		.collectAsState(DownloadStatus.NOT_DOWNLOADED)
 	val scope = rememberCoroutineScope()
@@ -118,6 +130,9 @@ fun ArtistDetailScreen(
 	}
 
 	var showDownloadDialog by remember { mutableStateOf(false) }
+
+	var shareId by remember { mutableStateOf<String?>(null) }
+	var shareExpiry by remember { mutableStateOf<Duration?>(null) }
 
 	Scaffold(
 		topBar = {
@@ -261,10 +276,36 @@ fun ArtistDetailScreen(
 										rows = GridCells.Fixed(3),
 										modifier = Modifier.fillMaxWidth().height(250.dp)
 									) {
-										items(songs) { song ->
+										itemsIndexed(songs) { index, song ->
+											val download = allDownloads.find { it.songId == song.id }
 											SongRow(
 												modifier = Modifier.weight(1f),
-												song = song
+												song = song,
+												selected = selection == song,
+												onClick = {
+													if (playerState.currentSong?.id != song.id) {
+														player.clearQueue()
+														songs.forEach { player.addToQueueSingle(it) }
+														player.playAt(index)
+													} else {
+														player.togglePlay()
+													}
+												},
+												onLongClick = {
+													viewModel.selectSong(song)
+												},
+												onDismissRequest = { viewModel.clearSelection() },
+												starredState = starredState,
+												onAddStar = { viewModel.starSelectedSong() },
+												onRemoveStar = { viewModel.unstarSelectedSong() },
+												download = download,
+												onDownload = { viewModel.downloadSong(song) },
+												onCancelDownload = { viewModel.cancelDownload(song.id) },
+												onDeleteDownload = { viewModel.deleteDownload(song.id) },
+												onPlayNext = { player.playNextSingle(song) },
+												onAddToQueue = { player.addToQueueSingle(song) },
+												onShare = { shareId = song.id },
+												isOnline = isOnline
 											)
 										}
 									}
@@ -321,6 +362,14 @@ fun ArtistDetailScreen(
 			}
 		}
 	}
+	
+	@Suppress("AssignedValueIsNeverRead")
+	ShareDialog(
+		id = shareId,
+		onIdClear = { shareId = null; viewModel.clearSelection() },
+		expiry = shareExpiry,
+		onExpiryChange = { shareExpiry = it }
+	)
 }
 
 fun truncateText(text: String, limit: Int): String {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -51,6 +52,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import navic.composeapp.generated.resources.Res
@@ -83,10 +85,12 @@ import paige.navic.ui.components.layouts.ArtCarousel
 import paige.navic.ui.components.layouts.ArtCarouselItem
 import paige.navic.ui.components.layouts.ArtGridItem
 import paige.navic.ui.components.layouts.RootBottomBar
+import paige.navic.ui.components.sheets.CollectionSheet
 import paige.navic.ui.screens.artist.components.ArtistActionButtons
 import paige.navic.ui.screens.artist.components.ArtistDetailScreenHeading
 import paige.navic.ui.screens.artist.components.ArtistDetailScreenTopBar
 import paige.navic.ui.screens.artist.viewmodels.ArtistDetailViewModel
+import paige.navic.ui.screens.playlist.dialogs.PlaylistUpdateDialog
 import paige.navic.ui.screens.share.dialogs.ShareDialog
 import paige.navic.utils.LocalBottomBarScrollManager
 import paige.navic.utils.UiState
@@ -107,6 +111,10 @@ fun ArtistDetailScreen(
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
 	val selection by viewModel.selectedSong.collectAsState()
+	val starredState by viewModel.starredState.collectAsState()
+
+	val selectedAlbum by viewModel.selectedAlbum.collectAsState()
+	val starredAlbumState by viewModel.starredAlbumState.collectAsState()
 
 	val downloadManager = koinInject<DownloadManager>()
 	val density = LocalDensity.current
@@ -115,7 +123,6 @@ fun ArtistDetailScreen(
 	val artistState by viewModel.artistState.collectAsState()
 	val isOnline by viewModel.isOnline.collectAsState()
 	val allDownloads by viewModel.allDownloads.collectAsState()
-	val starredState by viewModel.starredState.collectAsState()
 	val downloadStatus by viewModel.collectionDownloadStatus()
 		.collectAsState(DownloadStatus.NOT_DOWNLOADED)
 	val scope = rememberCoroutineScope()
@@ -133,6 +140,8 @@ fun ArtistDetailScreen(
 
 	var shareId by remember { mutableStateOf<String?>(null) }
 	var shareExpiry by remember { mutableStateOf<Duration?>(null) }
+
+	var playlistDialogShown by rememberSaveable { mutableStateOf(false) }
 
 	Scaffold(
 		topBar = {
@@ -315,8 +324,27 @@ fun ArtistDetailScreen(
 								state.albums.sortedByDescending { album -> album.playCount }
 									.toImmutableList()
 							) { album ->
-								ArtCarouselItem(album.coverArtId, album.name, null) {
+								val isStarred = (starredAlbumState as? UiState.Success)?.data
+								ArtCarouselItem(
+									coverArtId = album.coverArtId, 
+									title = album.name, 
+									contentDescription = null,
+									onSelect = { viewModel.selectAlbum(album) }
+								) {
 									backStack.add(Screen.CollectionDetail(album.id, "artist"))
+								}
+								if (selectedAlbum == album) {
+									CollectionSheet(
+										onDismissRequest = { viewModel.clearAlbumSelection() },
+										collection = album,
+										starred = if (isStarred == null) false else isStarred,
+										onShare = { shareId = album.id },
+										onPlayNext = { player.playNext(album) },
+										onAddToQueue = { player.addToQueue(album) },
+										onSetStarred = { viewModel.starAlbum(starredAlbumState) },
+										onAddAllToPlaylist = { playlistDialogShown = true },
+										isOnline = isOnline,
+									)
 								}
 							}
 							Text(
@@ -370,6 +398,14 @@ fun ArtistDetailScreen(
 		expiry = shareExpiry,
 		onExpiryChange = { shareExpiry = it }
 	)
+
+	if (playlistDialogShown) {
+		@Suppress("AssignedValueIsNeverRead")
+		PlaylistUpdateDialog(
+			songs = selectedAlbum?.songs.orEmpty().toPersistentList(),
+			onDismissRequest = { playlistDialogShown = false }
+		)
+	}
 }
 
 fun truncateText(text: String, limit: Int): String {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
@@ -111,10 +111,10 @@ fun ArtistDetailScreen(
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
 	val selection by viewModel.selectedSong.collectAsState()
-	val starredState by viewModel.starredState.collectAsState()
+	val songStarredState by viewModel.songStarredState.collectAsState()
 
 	val selectedAlbum by viewModel.selectedAlbum.collectAsState()
-	val starredAlbumState by viewModel.starredAlbumState.collectAsState()
+	val albumStarredState by viewModel.albumStarredState.collectAsState()
 
 	val downloadManager = koinInject<DownloadManager>()
 	val density = LocalDensity.current
@@ -304,7 +304,7 @@ fun ArtistDetailScreen(
 													viewModel.selectSong(song)
 												},
 												onDismissRequest = { viewModel.clearSelection() },
-												starredState = starredState,
+												starredState = songStarredState,
 												onAddStar = { viewModel.starSelectedSong() },
 												onRemoveStar = { viewModel.unstarSelectedSong() },
 												download = download,
@@ -324,7 +324,6 @@ fun ArtistDetailScreen(
 								state.albums.sortedByDescending { album -> album.playCount }
 									.toImmutableList()
 							) { album ->
-								val isStarred = (starredAlbumState as? UiState.Success)?.data
 								ArtCarouselItem(
 									coverArtId = album.coverArtId, 
 									title = album.name, 
@@ -337,11 +336,11 @@ fun ArtistDetailScreen(
 									CollectionSheet(
 										onDismissRequest = { viewModel.clearAlbumSelection() },
 										collection = album,
-										starred = if (isStarred == null) false else isStarred,
+										starred = albumStarredState,
 										onShare = { shareId = album.id },
 										onPlayNext = { player.playNext(album) },
 										onAddToQueue = { player.addToQueue(album) },
-										onSetStarred = { viewModel.starAlbum(starredAlbumState) },
+										onSetStarred = { viewModel.starAlbum(!albumStarredState) },
 										onAddAllToPlaylist = { playlistDialogShown = true },
 										isOnline = isOnline,
 									)

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.verticalScroll
@@ -43,8 +42,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -52,8 +51,8 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_see_all
@@ -74,8 +73,6 @@ import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.data.models.Screen
 import paige.navic.data.models.settings.Settings
 import paige.navic.data.models.settings.enums.BottomBarVisibilityMode
-import paige.navic.domain.models.DomainSong
-import paige.navic.domain.models.DomainSongCollection
 import paige.navic.managers.DownloadManager
 import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.ui.components.common.ErrorBox
@@ -110,19 +107,21 @@ fun ArtistDetailScreen(
 	val player = koinViewModel<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
-	val selection by viewModel.selectedSong.collectAsState()
-	val songStarredState by viewModel.songStarredState.collectAsState()
+	val selection by viewModel.selectedSong.collectAsStateWithLifecycle()
+	val selectedSongIsStarred by viewModel.selectedSongIsStarred.collectAsStateWithLifecycle()
+	val selectedSongRating by viewModel.selectedSongRating.collectAsStateWithLifecycle()
 
-	val selectedAlbum by viewModel.selectedAlbum.collectAsState()
-	val albumStarredState by viewModel.albumStarredState.collectAsState()
+	val selectedAlbum by viewModel.selectedAlbum.collectAsStateWithLifecycle()
+	val selectedAlbumIsStarred by viewModel.selectedAlbumIsStarred.collectAsStateWithLifecycle()
+	val selectedAlbumRating by viewModel.selectedAlbumRating.collectAsStateWithLifecycle()
 
 	val downloadManager = koinInject<DownloadManager>()
 	val density = LocalDensity.current
 	val backStack = LocalNavStack.current
 	val layoutDirection = LocalLayoutDirection.current
-	val artistState by viewModel.artistState.collectAsState()
-	val isOnline by viewModel.isOnline.collectAsState()
-	val allDownloads by viewModel.allDownloads.collectAsState()
+	val artistState by viewModel.artistState.collectAsStateWithLifecycle()
+	val isOnline by viewModel.isOnline.collectAsStateWithLifecycle()
+	val allDownloads by viewModel.allDownloads.collectAsStateWithLifecycle()
 	val downloadStatus by viewModel.collectionDownloadStatus()
 		.collectAsState(DownloadStatus.NOT_DOWNLOADED)
 	val scope = rememberCoroutineScope()
@@ -304,7 +303,7 @@ fun ArtistDetailScreen(
 													viewModel.selectSong(song)
 												},
 												onDismissRequest = { viewModel.clearSelection() },
-												starredState = songStarredState,
+												starredState = selectedSongIsStarred,
 												onAddStar = { viewModel.starSelectedSong() },
 												onRemoveStar = { viewModel.unstarSelectedSong() },
 												download = download,
@@ -314,7 +313,9 @@ fun ArtistDetailScreen(
 												onPlayNext = { player.playNextSingle(song) },
 												onAddToQueue = { player.addToQueueSingle(song) },
 												onShare = { shareId = song.id },
-												isOnline = isOnline
+												isOnline = isOnline,
+												rating = selectedSongRating,
+												onSetRating = { viewModel.rateSelectedSong(it) }
 											)
 										}
 									}
@@ -336,13 +337,15 @@ fun ArtistDetailScreen(
 									CollectionSheet(
 										onDismissRequest = { viewModel.clearAlbumSelection() },
 										collection = album,
-										starred = albumStarredState,
+										starred = selectedAlbumIsStarred,
 										onShare = { shareId = album.id },
 										onPlayNext = { player.playNext(album) },
 										onAddToQueue = { player.addToQueue(album) },
-										onSetStarred = { viewModel.starAlbum(!albumStarredState) },
+										onSetStarred = { viewModel.starAlbum(!selectedAlbumIsStarred) },
 										onAddAllToPlaylist = { playlistDialogShown = true },
 										isOnline = isOnline,
+										rating = selectedAlbumRating,
+										onSetRating = { viewModel.rateSelectedAlbum(it) }
 									)
 								}
 							}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
@@ -101,7 +101,7 @@ fun ArtistDetailScreenHeading(
 							}
 						},
 						style = MaterialTheme.typography.bodySmall,
-						color = Color.LightGray,
+						color = MaterialTheme.colorScheme.onSurfaceVariant,
 						modifier = Modifier.widthIn(max = 500.dp)
 					)
 				}
@@ -109,7 +109,6 @@ fun ArtistDetailScreenHeading(
 					text = artistName,
 					style = MaterialTheme.typography.displaySmall.copy(
 						fontWeight = FontWeight.Bold,
-						color = Color.White
 					),
 					modifier = Modifier
 						.fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
@@ -1,5 +1,6 @@
 package paige.navic.ui.screens.artist.components
 
+import android.content.res.Resources
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -50,6 +52,7 @@ fun ArtistDetailScreenHeading(
 ) {
 	val layoutDirection = LocalLayoutDirection.current
 	val progress by animateFloatAsState(if (scrolled) 0f else 1f)
+	val scale = Resources.getSystem().getDisplayMetrics().density
 	BoxWithConstraints(
 		modifier = Modifier.fillMaxWidth()
 	) {
@@ -70,9 +73,10 @@ fun ArtistDetailScreenHeading(
 					.fillMaxSize()
 					.background(
 						Brush.linearGradient(
-							colors = listOf(Color.Black, Color.Transparent),
+							0.025f to MaterialTheme.colorScheme.background,
+							1.0f to Color.Transparent,
 							start = Offset(0f, Float.POSITIVE_INFINITY),
-							end = Offset(Float.POSITIVE_INFINITY, 0f)
+							end = Offset(0f, 0f)
 						)
 					)
 			)
@@ -80,7 +84,7 @@ fun ArtistDetailScreenHeading(
 			Column(
 				modifier = Modifier
 					.align(Alignment.BottomStart)
-					.padding(horizontal = 20.dp, vertical = 24.dp)
+					.padding(horizontal = 20.dp)
 					.padding(start = innerPadding.calculateStartPadding(layoutDirection))
 					.padding(end = innerPadding.calculateEndPadding(layoutDirection)),
 				verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -99,7 +98,7 @@ fun ArtistDetailScreenHeading(
 							}
 						},
 						style = MaterialTheme.typography.bodySmall,
-						color = MaterialTheme.colorScheme.onSurfaceVariant,
+						color = MaterialTheme.colorScheme.onSurface,
 						modifier = Modifier.widthIn(max = 500.dp)
 					)
 				}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailHeading.kt
@@ -1,6 +1,5 @@
 package paige.navic.ui.screens.artist.components
 
-import android.content.res.Resources
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -52,7 +51,6 @@ fun ArtistDetailScreenHeading(
 ) {
 	val layoutDirection = LocalLayoutDirection.current
 	val progress by animateFloatAsState(if (scrolled) 0f else 1f)
-	val scale = Resources.getSystem().getDisplayMetrics().density
 	BoxWithConstraints(
 		modifier = Modifier.fillMaxWidth()
 	) {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
@@ -53,16 +53,16 @@ class ArtistDetailViewModel(
 	val artistState = _artistState.asStateFlow()
 
 	private val _selectedSong = MutableStateFlow<DomainSong?>(null)
-	val selectedSong: StateFlow<DomainSong?> = _selectedSong.asStateFlow()
+	val selectedSong = _selectedSong.asStateFlow()
 
-	private val _starredState = MutableStateFlow<UiState<Boolean>>(UiState.Success(false))
-	val starredState = _starredState.asStateFlow()
+	private val _songStarredState = MutableStateFlow(false)
+	val songStarredState = _songStarredState.asStateFlow()
 
 	private val _selectedAlbum = MutableStateFlow<DomainAlbum?>(null)
-	val selectedAlbum: StateFlow<DomainAlbum?> = _selectedAlbum.asStateFlow()
+	val selectedAlbum = _selectedAlbum.asStateFlow()
 
-	private val _starredAlbumState = MutableStateFlow<UiState<Boolean>>(UiState.Success(false))
-	val starredAlbumState = _starredAlbumState.asStateFlow()
+	private val _albumStarredState = MutableStateFlow(false)
+	val albumStarredState = _albumStarredState.asStateFlow()
 
 	val isOnline = connectivityManager.isOnline
 
@@ -138,13 +138,7 @@ class ArtistDetailViewModel(
 	fun selectSong(song: DomainSong) {
 		viewModelScope.launch {
 			_selectedSong.value = song
-			_starredState.value = UiState.Loading()
-			try {
-				val isStarred = collectionRepository.isSongStarred(song.id)
-				_starredState.value = UiState.Success(isStarred)
-			} catch (e: Exception) {
-				_starredState.value = UiState.Error(e)
-			}
+			_songStarredState.value = collectionRepository.isSongStarred(song.id)
 		}
 	}
 
@@ -155,13 +149,7 @@ class ArtistDetailViewModel(
 	fun selectAlbum(album: DomainAlbum) {
 		viewModelScope.launch {
 			_selectedAlbum.value = album
-			_starredAlbumState.value = UiState.Loading()
-			try {
-				val isStarred = albumRepository.isAlbumStarred(album)
-				_starredState.value = UiState.Success(isStarred)
-			} catch (e: Exception) {
-				_starredState.value = UiState.Error(e)
-			}
+			_albumStarredState.value = albumRepository.isAlbumStarred(album)
 		}
 	}
 
@@ -189,17 +177,16 @@ class ArtistDetailViewModel(
 		}
 	}
 
-	fun starAlbum(starred: UiState<Boolean>) {
+	fun starAlbum(starred: Boolean) {
 		viewModelScope.launch {
 			val selection = _selectedAlbum.value ?: return@launch
-			val isStarred = (starredAlbumState as? UiState.Success<Boolean>)?.data
 			runCatching {
-				if (isStarred != null && isStarred) {
+				if (starred) {
 					albumRepository.starAlbum(selection)
 				} else {
 					albumRepository.unstarAlbum(selection)
 				}
-				_starredAlbumState.value = starred
+				_albumStarredState.value = starred
 			}
 		}
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -22,9 +21,9 @@ import paige.navic.data.database.mappers.toDomainModel
 import paige.navic.domain.models.DomainAlbum
 import paige.navic.domain.models.DomainArtist
 import paige.navic.domain.models.DomainSong
-import paige.navic.domain.repositories.DbRepository
-import paige.navic.domain.repositories.CollectionRepository
 import paige.navic.domain.repositories.AlbumRepository
+import paige.navic.domain.repositories.DbRepository
+import paige.navic.domain.repositories.SongRepository
 import paige.navic.managers.ConnectivityManager
 import paige.navic.managers.DownloadManager
 import paige.navic.shared.Logger
@@ -42,7 +41,7 @@ data class ArtistState(
 class ArtistDetailViewModel(
 	private val artistId: String,
 	private val repository: DbRepository,
-	private val collectionRepository: CollectionRepository,
+	private val songRepository: SongRepository,
 	private val albumRepository: AlbumRepository,
 	private val artistDao: ArtistDao,
 	private val albumDao: AlbumDao,
@@ -55,14 +54,20 @@ class ArtistDetailViewModel(
 	private val _selectedSong = MutableStateFlow<DomainSong?>(null)
 	val selectedSong = _selectedSong.asStateFlow()
 
-	private val _songStarredState = MutableStateFlow(false)
-	val songStarredState = _songStarredState.asStateFlow()
+	private val _selectedSongIsStarred = MutableStateFlow(false)
+	val selectedSongIsStarred = _selectedSongIsStarred.asStateFlow()
+
+	private val _selectedSongRating = MutableStateFlow(0)
+	val selectedSongRating = _selectedSongRating.asStateFlow()
 
 	private val _selectedAlbum = MutableStateFlow<DomainAlbum?>(null)
 	val selectedAlbum = _selectedAlbum.asStateFlow()
 
-	private val _albumStarredState = MutableStateFlow(false)
-	val albumStarredState = _albumStarredState.asStateFlow()
+	private val _selectedAlbumIsStarred = MutableStateFlow(false)
+	val selectedAlbumIsStarred = _selectedAlbumIsStarred.asStateFlow()
+
+	private val _selectedAlbumRating = MutableStateFlow(0)
+	val selectedAlbumRating = _selectedAlbumRating.asStateFlow()
 
 	val isOnline = connectivityManager.isOnline
 
@@ -138,7 +143,8 @@ class ArtistDetailViewModel(
 	fun selectSong(song: DomainSong) {
 		viewModelScope.launch {
 			_selectedSong.value = song
-			_songStarredState.value = collectionRepository.isSongStarred(song.id)
+			_selectedSongIsStarred.value = songRepository.isSongStarred(song)
+			_selectedSongRating.value = songRepository.getSongRating(song)
 		}
 	}
 
@@ -149,7 +155,18 @@ class ArtistDetailViewModel(
 	fun selectAlbum(album: DomainAlbum) {
 		viewModelScope.launch {
 			_selectedAlbum.value = album
-			_albumStarredState.value = albumRepository.isAlbumStarred(album)
+			_selectedAlbumIsStarred.value = albumRepository.isAlbumStarred(album)
+			_selectedAlbumRating.value = albumRepository.getAlbumRating(album)
+		}
+	}
+
+	fun rateSelectedAlbum(rating: Int) {
+		viewModelScope.launch {
+			val selection = _selectedAlbum.value ?: return@launch
+			runCatching {
+				_selectedAlbumRating.value = rating
+				albumRepository.rateAlbum(selection, rating)
+			}
 		}
 	}
 
@@ -159,20 +176,30 @@ class ArtistDetailViewModel(
 
 	fun starSelectedSong() {
 		viewModelScope.launch {
-			try {
-				collectionRepository.starSong(_selectedSong.value!!)
-			} catch (e: Exception) {
-				Logger.e("CollectionDetailViewModel", "Failed to star song", e)
+			val selection = _selectedSong.value ?: return@launch
+			runCatching {
+				_selectedSongIsStarred.value = true
+				songRepository.starSong(selection)
 			}
 		}
 	}
 
 	fun unstarSelectedSong() {
 		viewModelScope.launch {
-			try {
-				collectionRepository.unstarSong(_selectedSong.value!!)
-			} catch (e: Exception) {
-				Logger.e("CollectionDetailViewModel", "Failed to unstar song", e)
+			val selection = _selectedSong.value ?: return@launch
+			runCatching {
+				_selectedSongIsStarred.value = false
+				songRepository.unstarSong(selection)
+			}
+		}
+	}
+
+	fun rateSelectedSong(rating: Int) {
+		viewModelScope.launch {
+			val selection = _selectedSong.value ?: return@launch
+			runCatching {
+				_selectedSongRating.value = rating
+				songRepository.rateSong(selection, rating)
 			}
 		}
 	}
@@ -186,7 +213,7 @@ class ArtistDetailViewModel(
 				} else {
 					albumRepository.unstarAlbum(selection)
 				}
-				_albumStarredState.value = starred
+				_selectedAlbumIsStarred.value = starred
 			}
 		}
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
@@ -7,10 +7,13 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import paige.navic.data.database.dao.AlbumDao
 import paige.navic.data.database.dao.ArtistDao
@@ -20,6 +23,7 @@ import paige.navic.domain.models.DomainAlbum
 import paige.navic.domain.models.DomainArtist
 import paige.navic.domain.models.DomainSong
 import paige.navic.domain.repositories.DbRepository
+import paige.navic.domain.repositories.CollectionRepository
 import paige.navic.managers.ConnectivityManager
 import paige.navic.managers.DownloadManager
 import paige.navic.shared.Logger
@@ -37,6 +41,7 @@ data class ArtistState(
 class ArtistDetailViewModel(
 	private val artistId: String,
 	private val repository: DbRepository,
+	private val collectionRepository: CollectionRepository,
 	private val artistDao: ArtistDao,
 	private val albumDao: AlbumDao,
 	private val downloadManager: DownloadManager,
@@ -45,7 +50,20 @@ class ArtistDetailViewModel(
 	private val _artistState = MutableStateFlow<UiState<ArtistState>>(UiState.Loading())
 	val artistState = _artistState.asStateFlow()
 
+	private val _selectedSong = MutableStateFlow<DomainSong?>(null)
+	val selectedSong: StateFlow<DomainSong?> = _selectedSong.asStateFlow()
+
+	private val _starredState = MutableStateFlow<UiState<Boolean>>(UiState.Success(false))
+	val starredState = _starredState.asStateFlow()
+
 	val isOnline = connectivityManager.isOnline
+
+	val allDownloads = downloadManager.allDownloads
+		.stateIn(
+			scope = viewModelScope,
+			started = SharingStarted.Lazily,
+			initialValue = emptyList()
+		)
 
 	val scrollState = ScrollState(initial = 0)
 
@@ -109,6 +127,43 @@ class ArtistDetailViewModel(
 		}
 	}
 
+	fun selectSong(song: DomainSong) {
+		viewModelScope.launch {
+			_selectedSong.value = song
+			_starredState.value = UiState.Loading()
+			try {
+				val isStarred = collectionRepository.isSongStarred(song.id)
+				_starredState.value = UiState.Success(isStarred)
+			} catch (e: Exception) {
+				_starredState.value = UiState.Error(e)
+			}
+		}
+	}
+
+	fun clearSelection() {
+		_selectedSong.value = null
+	}
+
+	fun starSelectedSong() {
+		viewModelScope.launch {
+			try {
+				collectionRepository.starSong(_selectedSong.value!!)
+			} catch (e: Exception) {
+				Logger.e("CollectionDetailViewModel", "Failed to star song", e)
+			}
+		}
+	}
+
+	fun unstarSelectedSong() {
+		viewModelScope.launch {
+			try {
+				collectionRepository.unstarSong(_selectedSong.value!!)
+			} catch (e: Exception) {
+				Logger.e("CollectionDetailViewModel", "Failed to unstar song", e)
+			}
+		}
+	}
+
 	fun playArtistAlbums(player: MediaPlayerViewModel) {
 		(_artistState.value as? UiState.Success)?.data?.let { state ->
 			player.clearQueue()
@@ -117,6 +172,18 @@ class ArtistDetailViewModel(
 			}
 			player.togglePlay()
 		}
+	}
+
+	fun downloadSong(song: DomainSong) {
+		downloadManager.downloadSong(song)
+	}
+
+	fun cancelDownload(songId: String) {
+		downloadManager.cancelDownload(songId)
+	}
+
+	fun deleteDownload(songId: String) {
+		downloadManager.deleteDownload(songId)
 	}
 
 	@OptIn(ExperimentalCoroutinesApi::class)

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
@@ -24,6 +24,7 @@ import paige.navic.domain.models.DomainArtist
 import paige.navic.domain.models.DomainSong
 import paige.navic.domain.repositories.DbRepository
 import paige.navic.domain.repositories.CollectionRepository
+import paige.navic.domain.repositories.AlbumRepository
 import paige.navic.managers.ConnectivityManager
 import paige.navic.managers.DownloadManager
 import paige.navic.shared.Logger
@@ -42,6 +43,7 @@ class ArtistDetailViewModel(
 	private val artistId: String,
 	private val repository: DbRepository,
 	private val collectionRepository: CollectionRepository,
+	private val albumRepository: AlbumRepository,
 	private val artistDao: ArtistDao,
 	private val albumDao: AlbumDao,
 	private val downloadManager: DownloadManager,
@@ -55,6 +57,12 @@ class ArtistDetailViewModel(
 
 	private val _starredState = MutableStateFlow<UiState<Boolean>>(UiState.Success(false))
 	val starredState = _starredState.asStateFlow()
+
+	private val _selectedAlbum = MutableStateFlow<DomainAlbum?>(null)
+	val selectedAlbum: StateFlow<DomainAlbum?> = _selectedAlbum.asStateFlow()
+
+	private val _starredAlbumState = MutableStateFlow<UiState<Boolean>>(UiState.Success(false))
+	val starredAlbumState = _starredAlbumState.asStateFlow()
 
 	val isOnline = connectivityManager.isOnline
 
@@ -144,6 +152,23 @@ class ArtistDetailViewModel(
 		_selectedSong.value = null
 	}
 
+	fun selectAlbum(album: DomainAlbum) {
+		viewModelScope.launch {
+			_selectedAlbum.value = album
+			_starredAlbumState.value = UiState.Loading()
+			try {
+				val isStarred = albumRepository.isAlbumStarred(album)
+				_starredState.value = UiState.Success(isStarred)
+			} catch (e: Exception) {
+				_starredState.value = UiState.Error(e)
+			}
+		}
+	}
+
+	fun clearAlbumSelection() {
+		_selectedAlbum.value = null
+	}
+
 	fun starSelectedSong() {
 		viewModelScope.launch {
 			try {
@@ -160,6 +185,21 @@ class ArtistDetailViewModel(
 				collectionRepository.unstarSong(_selectedSong.value!!)
 			} catch (e: Exception) {
 				Logger.e("CollectionDetailViewModel", "Failed to unstar song", e)
+			}
+		}
+	}
+
+	fun starAlbum(starred: UiState<Boolean>) {
+		viewModelScope.launch {
+			val selection = _selectedAlbum.value ?: return@launch
+			val isStarred = (starredAlbumState as? UiState.Success<Boolean>)?.data
+			runCatching {
+				if (isStarred != null && isStarred) {
+					albumRepository.starAlbum(selection)
+				} else {
+					albumRepository.unstarAlbum(selection)
+				}
+				_starredAlbumState.value = starred
 			}
 		}
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/MoreByArtistRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/MoreByArtistRow.kt
@@ -14,7 +14,7 @@ import paige.navic.ui.components.layouts.ArtCarouselItem
 fun LazyListScope.collectionDetailScreenMoreByArtistRow(
 	artistName: String,
 	artistAlbums: List<DomainAlbum>,
-	tab: String
+	tab: String,
 ) {
 	item {
 		val backStack = LocalNavStack.current


### PR DESCRIPTION
- The artist's image now blends into the background
- Tapping on one of the frequently played songs now starts a queue of all the songs in that list, rather than just that one song
- SongRow (used for frequently played songs) now has offline and downloading indicators
- Frequently played songs now open a SongSheet on long-press
- Albums in ArtCarousel now open a CollectionSheet on long-press