### PR TITLE
feat(android): optimize imports

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/data/database/mappers/RadioMappers.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/data/database/mappers/RadioMappers.kt
@@ -1,8 +1,8 @@
 package paige.navic.data.database.mappers
 
-import dev.zt64.subsonic.api.model.InternetRadioStation as ApiRadio
 import paige.navic.data.database.entities.RadioEntity
 import paige.navic.domain.models.DomainRadio
+import dev.zt64.subsonic.api.model.InternetRadioStation as ApiRadio
 
 fun ApiRadio.toEntity() = RadioEntity(
 	radioId = id,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/PullToRefreshBox.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/PullToRefreshBox.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox as M3PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -18,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox as M3PullToRefreshBox
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistListScreen.kt
@@ -36,8 +36,8 @@ import paige.navic.ui.components.common.Dropdown
 import paige.navic.ui.components.common.DropdownItem
 import paige.navic.ui.components.common.ErrorSnackbar
 import paige.navic.ui.components.layouts.ArtGridItem
-import paige.navic.ui.components.layouts.PullToRefreshBox
 import paige.navic.ui.components.layouts.NestedTopBar
+import paige.navic.ui.components.layouts.PullToRefreshBox
 import paige.navic.ui.components.layouts.RootBottomBar
 import paige.navic.ui.components.layouts.RootTopBar
 import paige.navic.ui.screens.artist.components.ArtistListScreenContent

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/genre/GenreListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/genre/GenreListScreen.kt
@@ -21,8 +21,8 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.ui.components.common.ErrorSnackbar
 import paige.navic.ui.components.layouts.ArtGrid
-import paige.navic.ui.components.layouts.PullToRefreshBox
 import paige.navic.ui.components.layouts.NestedTopBar
+import paige.navic.ui.components.layouts.PullToRefreshBox
 import paige.navic.ui.components.layouts.RootBottomBar
 import paige.navic.ui.components.layouts.RootTopBar
 import paige.navic.ui.screens.genre.components.genreListScreenContent

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/components/KaraokeText.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/components/KaraokeText.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.ResolvedTextDirection
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import paige.navic.data.models.settings.Settings
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/playlist/components/Item.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/playlist/components/Item.kt
@@ -4,10 +4,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.dropUnlessResumed
 import kotlinx.collections.immutable.toPersistentList
@@ -21,10 +21,10 @@ import paige.navic.LocalNavStack
 import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.data.models.Screen
 import paige.navic.domain.models.DomainPlaylist
+import paige.navic.managers.DownloadManager
 import paige.navic.ui.components.layouts.ArtGridItem
 import paige.navic.ui.components.sheets.CollectionSheet
 import paige.navic.ui.screens.playlist.dialogs.PlaylistUpdateDialog
-import paige.navic.managers.DownloadManager
 
 @Composable
 fun PlaylistListScreenItem(

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/radio/components/Card.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/radio/components/Card.kt
@@ -1,7 +1,15 @@
 package paige.navic.ui.screens.radio.components
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/share/ShareListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/share/ShareListScreen.kt
@@ -35,8 +35,8 @@ import paige.navic.icons.filled.ShareOff
 import paige.navic.ui.components.common.ContentUnavailable
 import paige.navic.ui.components.dialogs.DeletionDialog
 import paige.navic.ui.components.dialogs.DeletionEndpoint
-import paige.navic.ui.components.layouts.PullToRefreshBox
 import paige.navic.ui.components.layouts.NestedTopBar
+import paige.navic.ui.components.layouts.PullToRefreshBox
 import paige.navic.ui.components.layouts.RootBottomBar
 import paige.navic.ui.components.layouts.artGridError
 import paige.navic.ui.screens.share.components.ShareListScreenItem


### PR DESCRIPTION
this shrimply optimizes imports across 8 files with small changes, except for Card.kt where it no longer imports everything from compose layout