### PR TITLE
feat(playback): replaygain mode picker (#299)

### DIFF
--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -358,7 +358,7 @@ class AndroidMediaPlayerViewModel(
 		viewModelScope.launch {
 			if (Settings.shared.replayGain) {
 				(_uiState.value.currentSong)?.replayGain?.let { replayGain ->
-					controller?.volume = replayGain.effectiveGain()
+					controller?.volume = replayGain.effectiveGain(Settings.shared.replayGainMode)
 				}
 			} else {
 				controller?.volume = 1f

--- a/composeApp/src/commonMain/kotlin/paige/navic/data/models/settings/Settings.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/data/models/settings/Settings.kt
@@ -17,6 +17,7 @@ import paige.navic.data.models.settings.enums.NavigationBarStyle
 import paige.navic.data.models.settings.enums.NowPlayingBackgroundStyle
 import paige.navic.data.models.settings.enums.NowPlayingSliderStyle
 import paige.navic.data.models.settings.enums.OfflineMode
+import paige.navic.data.models.settings.enums.ReplayGainMode
 import paige.navic.data.models.settings.enums.StreamingQuality
 import paige.navic.data.models.settings.enums.Theme
 import paige.navic.data.models.settings.enums.ThemeMode
@@ -45,6 +46,7 @@ class Settings(
 	var scrobblePercentage by preference(.5f)
 	var minDurationToScrobble by preference(30f)
 	var replayGain by preference(false)
+	var replayGainMode by preference(ReplayGainMode.Track)
 	var gaplessPlayback by preference(true)
 	var audioOffload by preference(false)
 	var streamingQualityWifi by preference(StreamingQuality.Lossless)

--- a/composeApp/src/commonMain/kotlin/paige/navic/data/models/settings/enums/ReplayGainMode.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/data/models/settings/enums/ReplayGainMode.kt
@@ -1,0 +1,11 @@
+package paige.navic.data.models.settings.enums
+
+import navic.composeapp.generated.resources.Res
+import navic.composeapp.generated.resources.info_album_replay_gain
+import navic.composeapp.generated.resources.info_track_replay_gain
+import org.jetbrains.compose.resources.StringResource
+
+enum class ReplayGainMode(val displayName: StringResource) {
+	Track(Res.string.info_track_replay_gain),
+	Album(Res.string.info_album_replay_gain)
+}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/settings/PlaybackScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/settings/PlaybackScreen.kt
@@ -52,13 +52,16 @@ import paige.navic.LocalCtx
 import paige.navic.LocalNavStack
 import paige.navic.data.models.Screen
 import paige.navic.data.models.settings.Settings
+import paige.navic.data.models.settings.enums.ReplayGainMode
 import paige.navic.icons.Icons
 import paige.navic.icons.outlined.ChevronForward
 import paige.navic.ui.components.common.Form
 import paige.navic.ui.components.common.FormRow
 import paige.navic.ui.components.common.FormTitle
 import paige.navic.ui.components.layouts.NestedTopBar
+import paige.navic.ui.screens.settings.components.SettingSelectionRow
 import paige.navic.ui.screens.settings.components.SettingSwitchRow
+import kotlinx.collections.immutable.toImmutableList
 import paige.navic.ui.screens.settings.dialogs.LyricsPriorityDialog
 import kotlin.math.roundToInt
 
@@ -106,6 +109,15 @@ fun SettingsPlaybackScreen() {
 							value = Settings.shared.replayGain,
 							onSetValue = { Settings.shared.replayGain = it }
 						)
+						if (Settings.shared.replayGain) {
+							SettingSelectionRow(
+								title = { Text(stringResource(Res.string.option_replay_gain)) },
+								items = ReplayGainMode.entries.toImmutableList(),
+								label = { stringResource(it.displayName) },
+								selection = Settings.shared.replayGainMode,
+								onSelect = { Settings.shared.replayGainMode = it }
+							)
+						}
 						SettingSwitchRow(
 							title = { Text(stringResource(Res.string.option_gapless_playback)) },
 							subtitle = { Text(stringResource(Res.string.subtitle_gapless_playback)) },

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/song/SongDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/song/SongDetailScreen.kt
@@ -38,6 +38,7 @@ import navic.composeapp.generated.resources.info_unknown
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
+import paige.navic.data.models.settings.Settings
 import paige.navic.ui.components.common.Form
 import paige.navic.ui.components.common.FormRow
 import paige.navic.ui.components.layouts.NestedTopBar
@@ -80,7 +81,7 @@ fun SongDetailScreen(songId: String) {
 
 				Res.string.info_track_replay_gain to song.replayGain?.trackGain?.let { "$it dB" },
 				Res.string.info_album_replay_gain to song.replayGain?.albumGain?.let { "$it dB" },
-				Res.string.info_track_replay_gain_effective to song.replayGain?.effectiveGain()
+				Res.string.info_track_replay_gain_effective to song.replayGain?.effectiveGain(Settings.shared.replayGainMode)
 			)
 		}.orEmpty()
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/utils/ReplayGainUtils.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/utils/ReplayGainUtils.kt
@@ -1,9 +1,14 @@
 package paige.navic.utils
 
+import paige.navic.data.models.settings.enums.ReplayGainMode
 import paige.navic.domain.models.DomainReplayGain
 import kotlin.math.pow
 
-fun DomainReplayGain.effectiveGain(): Float {
-	val gain = trackGain ?: albumGain ?: fallbackGain ?: baseGain ?: 0f
+fun DomainReplayGain.effectiveGain(mode: ReplayGainMode = ReplayGainMode.Track): Float {
+	val gain = if (mode == ReplayGainMode.Track) {
+		trackGain ?: albumGain ?: fallbackGain ?: baseGain ?: 0f
+	} else {
+		albumGain ?: trackGain ?: fallbackGain ?: baseGain ?: 0f
+	}
 	return (10.0.pow((gain / 20.0)).toFloat()).coerceIn(0f..1f)
 }


### PR DESCRIPTION
lets the user pick between album/track gain instead of forcing track, defaults to track in order to maintain identical behaviour for those who don't wish to change this setting.

closes #299