### PR TITLE
Fix double playback issues

### DIFF
--- a/composeApp/src/androidMain/kotlin/paige/navic/di/PlatformModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/di/PlatformModule.android.kt
@@ -55,7 +55,7 @@ actual val platformModule = module {
 		)
 	}
 
-	viewModel<MediaPlayerViewModel> {
+	single<MediaPlayerViewModel> {
 		AndroidMediaPlayerViewModel(
 			application = androidApplication(),
 			stateRepository = get(),

--- a/composeApp/src/commonMain/kotlin/paige/navic/App.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/App.kt
@@ -50,7 +50,7 @@ import coil3.request.crossfade
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.data.images.initializeSingletonImageLoader
 import paige.navic.data.models.Screen
 import paige.navic.data.models.settings.Settings
@@ -262,7 +262,7 @@ private fun entryProvider(
 			NowPlayingScreen()
 		}
 		entry<Screen.Lyrics>(metadata = NowPlayingSceneStrategy.bottomSheet(isTransparent = true)) {
-			val player = koinViewModel<MediaPlayerViewModel>()
+			val player = koinInject<MediaPlayerViewModel>()
 			val playerState by player.uiState.collectAsState()
 			val song = playerState.currentSong
 			LyricsScreen(song)

--- a/composeApp/src/commonMain/kotlin/paige/navic/di/ViewModelModule.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/di/ViewModelModule.kt
@@ -15,6 +15,7 @@ import paige.navic.ui.screens.collection.viewmodels.CollectionDetailViewModel
 import paige.navic.ui.screens.genre.viewmodels.GenreListViewModel
 import paige.navic.ui.screens.login.viewmodels.LoginViewModel
 import paige.navic.ui.screens.lyrics.viewmodels.LyricsScreenViewModel
+import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.ui.screens.nowPlaying.viewmodels.NowPlayingViewModel
 import paige.navic.ui.screens.playlist.viewmodels.PlaylistCreateDialogViewModel
 import paige.navic.ui.screens.playlist.viewmodels.PlaylistListViewModel
@@ -72,7 +73,12 @@ val viewModelModule = module {
 	viewModelOf(::SongDetailViewModel)
 	viewModelOf(::SettingsDataStorageViewModel)
 	viewModelOf(::ChangelogViewModel)
-	viewModelOf(::NowPlayingViewModel)
+	viewModel { params ->
+		NowPlayingViewModel(
+			player = params.get(),
+			songRepository = get()
+		)
+	}
 	viewModel {
 		NavtabsViewModel(
 			settings = Settings(),

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/repositories/PlayerStateRepository.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/repositories/PlayerStateRepository.kt
@@ -15,9 +15,10 @@ class PlayerStateRepository(
 		val stateEntity = playerStateDao.getPlayerState(serverId) ?: return null
 		val queueEntities = playerStateDao.getQueue(serverId)
 
+		val queue = queueEntities.map { json.decodeFromString<DomainSong>(it.songJson) }
 		return PlayerUiState(
-			queue = queueEntities.map { json.decodeFromString<DomainSong>(it.songJson) },
-			currentSong = stateEntity.currentSongId?.let { null },
+			queue = queue,
+			currentSong = queue.getOrNull(stateEntity.currentIndex),
 			currentIndex = stateEntity.currentIndex,
 			isShuffleEnabled = stateEntity.isShuffleEnabled,
 			repeatMode = stateEntity.repeatMode,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/SongRow.kt
@@ -32,7 +32,7 @@ import navic.composeapp.generated.resources.info_not_available_offline
 import navic.composeapp.generated.resources.info_unknown_album
 import navic.composeapp.generated.resources.info_unknown_year
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.LocalNavStack
 import paige.navic.data.database.entities.DownloadEntity
 import paige.navic.data.database.entities.DownloadStatus
@@ -72,7 +72,7 @@ fun SongRow(
 	rating: Int,
 	onSetRating: (Int) -> Unit
 ) {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
 	val backStack = LocalNavStack.current

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/MiniPlayer.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/MiniPlayer.kt
@@ -59,6 +59,7 @@ import com.kyant.capsule.ContinuousRoundedRectangle
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.info_not_playing
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalCtx
 import paige.navic.LocalNavStack
@@ -87,7 +88,7 @@ fun MiniPlayer(
 	enabled: Boolean = true
 ) {
 	val ctx = LocalCtx.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val navtabsViewModel = koinViewModel<NavtabsViewModel>()
 	val navtabsState by navtabsViewModel.state.collectAsState()
 	val tabs = ((navtabsState as? UiState.Success)?.data ?: NavbarConfig.default)

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/scenes/NowPlayingScene.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/scenes/NowPlayingScene.kt
@@ -32,7 +32,7 @@ import com.materialkolor.rememberDynamicColorScheme
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.Url
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.data.session.SessionManager
 import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.ui.components.sheets.ModalBottomSheet
@@ -142,7 +142,7 @@ class NowPlayingSceneStrategy<T : Any> : SceneStrategy<T> {
 
 @Composable
 private fun colorSchemeForCurrentSong(): ColorScheme {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val song = playerState.currentSong
 	val coverUri = remember(song?.coverArtId) {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/album/AlbumListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/album/AlbumListScreen.kt
@@ -24,6 +24,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.title_albums
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import paige.navic.data.models.settings.Settings
@@ -55,7 +56,7 @@ fun AlbumListScreen(
 		key = listType.toString(),
 		parameters = { parametersOf(listType) }
 	)
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val pagedAlbums = viewModel.pagedAlbums.collectAsLazyPagingItems()
 	val selectedSorting by viewModel.listType.collectAsStateWithLifecycle()
 	val selectedReversed by viewModel.selectedReversed.collectAsStateWithLifecycle()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/ArtistDetailScreen.kt
@@ -112,7 +112,7 @@ fun ArtistDetailScreen(
 	var shareExpiry by remember { mutableStateOf<Duration?>(null) }
 	var bulkDownloadDialogShown by remember { mutableStateOf(false) }
 
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
 	val backStack = LocalNavStack.current

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailTopBar.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/components/DetailTopBar.kt
@@ -22,7 +22,7 @@ import kotlinx.collections.immutable.toPersistentList
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_more
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.icons.Icons
 import paige.navic.icons.outlined.MoreVert
 import paige.navic.shared.MediaPlayerViewModel
@@ -46,7 +46,7 @@ fun ArtistDetailScreenTopBar(
 		if (scrolled) 1f else 0f
 	)
 
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 
 	var playlistDialogShown by rememberSaveable { mutableStateOf(false) }
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/CollectionDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/CollectionDetailScreen.kt
@@ -35,6 +35,7 @@ import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.info_no_songs
 import navic.composeapp.generated.resources.title_disc_number
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import paige.navic.data.database.entities.DownloadStatus
@@ -75,7 +76,7 @@ fun CollectionDetailScreen(
 		parameters = { parametersOf(collectionId) }
 	)
 
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
 	val collectionState by viewModel.collectionState.collectAsState()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/HeadingRowButtons.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/HeadingRowButtons.kt
@@ -32,7 +32,6 @@ import navic.composeapp.generated.resources.action_shuffle
 import navic.composeapp.generated.resources.info_download_failed
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
-import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalCtx
 import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.domain.models.DomainSongCollection
@@ -52,7 +51,7 @@ fun CollectionDetailScreenHeadingRowButtons(
 	collection: DomainSongCollection
 ) {
 	val ctx = LocalCtx.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val downloadManager = koinInject<DownloadManager>()
 	val scope = rememberCoroutineScope()
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRow.kt
@@ -43,7 +43,7 @@ import navic.composeapp.generated.resources.info_download_failed
 import navic.composeapp.generated.resources.info_downloaded
 import navic.composeapp.generated.resources.info_not_available_offline
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.data.database.entities.DownloadEntity
 import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.domain.models.DomainExplicitStatus
@@ -76,7 +76,7 @@ fun CollectionDetailScreenSongRow(
 	download: DownloadEntity? = null,
 	isOffline: Boolean = false
 ) {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 
 	val isDownloaded = download?.status == DownloadStatus.DOWNLOADED

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRowDropdown.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRowDropdown.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.dropUnlessResumed
 import kotlinx.collections.immutable.persistentListOf
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.LocalNavStack
 import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.data.models.Screen
@@ -40,7 +40,7 @@ fun CollectionDetailScreenSongRowDropdown(
 	rating: Int,
 	onSetRating: (Int) -> Unit
 ) {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val backStack = LocalNavStack.current
 	var playlistDialogShown by rememberSaveable { mutableStateOf(false) }
 	var duplicateQueueDialogShown by rememberSaveable { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/library/LibraryScreen.kt
@@ -22,6 +22,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.title_library
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import paige.navic.domain.models.DomainAlbumListType
@@ -78,7 +79,7 @@ fun LibraryScreen() {
 	var playlistDeletionId by rememberSaveable { mutableStateOf<String?>(null) }
 	var playlistCreateDialogShown by rememberSaveable { mutableStateOf(false) }
 
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 
 	val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/LyricsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/LyricsScreen.kt
@@ -57,6 +57,7 @@ import navic.composeapp.generated.resources.info_no_lyrics
 import navic.composeapp.generated.resources.title_select_lyrics
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import paige.navic.LocalNavStack
@@ -96,7 +97,7 @@ fun LyricsScreen(
 		key = song?.id,
 		parameters = { parametersOf(song) }
 	)
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 	val state by viewModel.lyricsState.collectAsState()
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/NowPlayingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/NowPlayingScreen.kt
@@ -29,7 +29,9 @@ import navic.composeapp.generated.resources.action_navigate_back
 import navic.composeapp.generated.resources.action_queue
 import navic.composeapp.generated.resources.title_now_playing
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
 import paige.navic.LocalNavStack
 import paige.navic.data.models.Screen
 import paige.navic.data.models.settings.Settings
@@ -52,7 +54,7 @@ import paige.navic.ui.screens.nowPlaying.viewmodels.NowPlayingViewModel
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NowPlayingScreen() {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val backStack = LocalNavStack.current
 
 	val currentScreen = backStack.lastOrNull()
@@ -63,7 +65,7 @@ fun NowPlayingScreen() {
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 	val song = playerState.currentSong
 
-	val viewModel = koinViewModel<NowPlayingViewModel>()
+	val viewModel = koinViewModel<NowPlayingViewModel> { parametersOf(player) }
 	val songIsStarred by viewModel.songIsStarred.collectAsStateWithLifecycle()
 	val songRating by viewModel.songRating.collectAsStateWithLifecycle()
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/PlaybackScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/PlaybackScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousCapsule
 import com.kyant.capsule.ContinuousRoundedRectangle
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.utils.rememberDraggableListState
 import kotlin.math.round
@@ -33,7 +33,7 @@ import kotlin.math.round
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PlaybackSpeedScreen(
-	player: MediaPlayerViewModel = koinViewModel<MediaPlayerViewModel>(),
+	player: MediaPlayerViewModel = koinInject<MediaPlayerViewModel>(),
 ) {
 	val lazyListState = rememberLazyListState()
 	val haptic = LocalHapticFeedback.current

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/Artwork.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/Artwork.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.domain.models.DomainSong
 import paige.navic.icons.Icons
 import paige.navic.icons.filled.Note
@@ -29,7 +29,7 @@ fun NowPlayingArtwork(
 	isLandscape: Boolean,
 	song: DomainSong
 ) {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 
 	val isRadio = song.id.startsWith("radio_")

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/ArtworkPager.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/ArtworkPager.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.data.models.settings.Settings
 import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.ui.screens.nowPlaying.components.NowPlayingArtwork
@@ -32,7 +32,7 @@ fun NowPlayingArtworkPager(
 	modifier: Modifier = Modifier,
 	isLandscape: Boolean
 ) {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 
 	val pagerState = rememberPagerState(

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/MoreButton.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/MoreButton.kt
@@ -18,7 +18,7 @@ import kotlinx.collections.immutable.persistentListOf
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_more
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.LocalCtx
 import paige.navic.LocalNavStack
 import paige.navic.data.models.Screen
@@ -38,7 +38,7 @@ fun NowPlayingMoreButton(
 ) {
 	val backStack = LocalNavStack.current
 	val ctx = LocalCtx.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val song = playerState.currentSong
 	var expanded by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/ProgressBar.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/ProgressBar.kt
@@ -20,7 +20,7 @@ import ir.mahozad.multiplatform.wavyslider.material3.Track
 import ir.mahozad.multiplatform.wavyslider.material3.WaveAnimationSpecs
 import ir.mahozad.multiplatform.wavyslider.material3.WaveVelocity
 import ir.mahozad.multiplatform.wavyslider.material3.WavySlider
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.data.models.settings.Settings
 import paige.navic.data.models.settings.enums.NowPlayingSliderStyle
 import paige.navic.shared.MediaPlayerViewModel
@@ -29,7 +29,7 @@ import paige.navic.ui.components.common.SlimSlider
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NowPlayingProgressBar() {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val enabled = playerState.currentSong != null
 	val waveHeight by animateDpAsState(

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/StarButton.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/controls/StarButton.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_star
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.LocalCtx
 import paige.navic.icons.Icons
 import paige.navic.icons.filled.Star
@@ -25,7 +25,7 @@ fun NowPlayingStarButton(
 	onSetSongIsStarred: (Boolean) -> Unit
 ) {
 	val ctx = LocalCtx.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 	IconButton(
 		onClick = {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/ButtonsRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/ButtonsRow.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.LocalCtx
 import paige.navic.icons.Icons
 import paige.navic.icons.filled.Pause
@@ -50,7 +50,7 @@ import paige.navic.ui.components.common.playPauseIconPainter
 @Composable
 fun NowPlayingButtonsRow() {
 	val ctx = LocalCtx.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val interactionSource = remember { MutableInteractionSource() }
 	val isPressed by interactionSource.collectIsPressedAsState()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/DurationsRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/DurationsRow.kt
@@ -12,14 +12,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.unit.dp
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.utils.toHoursMinutesSeconds
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun NowPlayingDurationsRow() {
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val duration = playerState.currentSong?.duration
 	val style = MaterialTheme.typography.bodyMedium

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/InfoRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/InfoRow.kt
@@ -18,7 +18,7 @@ import androidx.lifecycle.compose.dropUnlessResumed
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.info_not_playing
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 import paige.navic.LocalNavStack
 import paige.navic.data.models.Screen
 import paige.navic.domain.models.DomainExplicitStatus
@@ -36,7 +36,7 @@ fun NowPlayingInfoRow(
 	onSetSongRating: (Int) -> Unit
 ) {
 	val backStack = LocalNavStack.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val song = playerState.currentSong
 	Row(

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/TechnicalInfoRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/components/rows/TechnicalInfoRow.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.compose.koinInject
-import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.data.models.settings.Settings
 import paige.navic.managers.ConnectivityManager
 import paige.navic.shared.MediaPlayerViewModel
@@ -27,7 +26,7 @@ import paige.navic.shared.MediaPlayerViewModel
 @Composable
 fun NowPlayingTechnicalInfoRow() {
 	val connectivityManager = koinInject<ConnectivityManager>()
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsState()
 	val song = playerState.currentSong
 

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/viewmodels/NowPlayingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/nowPlaying/viewmodels/NowPlayingViewModel.kt
@@ -5,15 +5,13 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import paige.navic.domain.repositories.SongRepository
 import paige.navic.shared.MediaPlayerViewModel
 
 class NowPlayingViewModel(
+	private val player: MediaPlayerViewModel,
 	private val songRepository: SongRepository
-) : ViewModel(), KoinComponent {
-	private val player: MediaPlayerViewModel by inject()
+) : ViewModel() {
 
 	private val _songIsStarred = MutableStateFlow(false)
 	val songIsStarred = _songIsStarred.asStateFlow()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/playlist/PlaylistListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/playlist/PlaylistListScreen.kt
@@ -40,6 +40,7 @@ import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.title_create_playlist
 import navic.composeapp.generated.resources.title_playlists
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalCtx
 import paige.navic.data.models.settings.Settings
@@ -73,7 +74,7 @@ fun PlaylistListScreen(
 	nested: Boolean = false
 ) {
 	val viewModel = koinViewModel<PlaylistListViewModel>()
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playlistsState by viewModel.playlistsState.collectAsState()
 	val selectedPlaylist by viewModel.selectedPlaylist.collectAsState()
 	val selectedSorting by viewModel.selectedSorting.collectAsStateWithLifecycle()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/queue/QueueScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/queue/QueueScreen.kt
@@ -30,6 +30,7 @@ import navic.composeapp.generated.resources.count_songs
 import navic.composeapp.generated.resources.info_no_queue
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalCtx
 import paige.navic.LocalNavStack
@@ -51,7 +52,7 @@ fun QueueScreen() {
 	val viewModel = koinViewModel<QueueViewModel>()
 	val ctx = LocalCtx.current
 	val backStack = LocalNavStack.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 	val isOnline by viewModel.isOnline.collectAsStateWithLifecycle()
 	val downloadedSongs by viewModel.downloadedSongs.collectAsStateWithLifecycle()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/radio/RadioListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/radio/RadioListScreen.kt
@@ -36,6 +36,7 @@ import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.title_create_playlist
 import navic.composeapp.generated.resources.title_radios
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalCtx
 import paige.navic.data.models.settings.Settings
@@ -64,7 +65,7 @@ fun RadioListScreen(
 	val ctx = LocalCtx.current
 	val scrollManager = LocalBottomBarScrollManager.current
 	val viewModel = koinViewModel<RadioListViewModel>()
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val radiosState by viewModel.radiosState.collectAsState()
 	val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
 	val slideSpec = MaterialTheme.motionScheme.defaultSpatialSpec<IntOffset>()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/search/SearchScreen.kt
@@ -53,6 +53,7 @@ import navic.composeapp.generated.resources.title_artists
 import navic.composeapp.generated.resources.title_songs
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import paige.navic.LocalCtx
@@ -126,7 +127,7 @@ fun SearchScreen(
 	val downloadedSongs by viewModel.downloadedSongs.collectAsState()
 
 	val ctx = LocalCtx.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val backStack = LocalNavStack.current
 
 	var selectedCategory by remember { mutableStateOf(SearchCategory.ALL) }

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/song/SongListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/song/SongListScreen.kt
@@ -26,6 +26,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.title_songs
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import paige.navic.data.models.settings.Settings
@@ -56,7 +57,7 @@ fun SongListScreen(
 		key = artistId,
 		parameters = { parametersOf(artistId) }
 	)
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val songs = viewModel.songsPaging.collectAsLazyPagingItems()
 	val selectedSong by viewModel.selectedSong.collectAsStateWithLifecycle()
 	val selectedSorting by viewModel.selectedSorting.collectAsStateWithLifecycle()

--- a/composeApp/src/iosMain/kotlin/paige/navic/di/PlatformModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/paige/navic/di/PlatformModule.ios.kt
@@ -55,7 +55,7 @@ actual val platformModule = module {
 		)
 	}
 
-	viewModel<MediaPlayerViewModel> {
+	single<MediaPlayerViewModel> {
 		IOSMediaPlayerViewModel(
 			stateRepository = get(),
 			downloadManager = get(),

--- a/composeApp/src/iosMain/kotlin/paige/navic/shared/MediaPlayer.ios.kt
+++ b/composeApp/src/iosMain/kotlin/paige/navic/shared/MediaPlayer.ios.kt
@@ -525,7 +525,6 @@ class IOSMediaPlayerViewModel(
 		player.pause()
 		player.replaceCurrentItemWithPlayerItem(null)
 		player.replaceCurrentItemWithPlayerItem(createAVPlayerItem(url))
-		player.setRate(state.playbackSpeed)
 
 		if (!song.id.startsWith("radio_")) {
 			val durationMs = song.duration.inWholeMilliseconds


### PR DESCRIPTION
This resolves #283 by making the player view model a singleton and removes a set playback rate call in the pause function on ios which would usually make avplayer begin playing. 