### PR TITLE
chore: bring back queue info

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -295,6 +295,7 @@
 	<string name="action_queue">Queue</string>
 	<string name="action_reorder">Reorder</string>
 	<string name="action_remove_from_queue">Remove from queue</string>
+	<string name="action_clear_queue">Clear queue</string>
 	<string name="action_search_history">Recent Searches</string>
 	<string name="action_remove_from_history">Remove from history</string>
 	<string name="action_clear_image_cache">Clear image cache</string>

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/artist/viewmodels/ArtistDetailViewModel.kt
@@ -103,7 +103,7 @@ class ArtistDetailViewModel(
 				val domainSongs = albumsWithSongs.flatMap { it.songs }
 					.map { it.toDomainModel() }
 					.sortedByDescending { it.playCount }
-					.take(10)
+					.take(12)
 
 				val initialSimilarArtists = domainArtist.similarArtistIds.mapNotNull { id ->
 					artistDao.getArtistById(id)?.toDomainModel()

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/queue/QueueScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/queue/QueueScreen.kt
@@ -1,28 +1,39 @@
 package paige.navic.ui.screens.queue
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousRoundedRectangle
 import navic.composeapp.generated.resources.Res
+import navic.composeapp.generated.resources.action_clear_queue
+import navic.composeapp.generated.resources.count_songs
 import navic.composeapp.generated.resources.info_no_queue
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
-import paige.navic.LocalPlatformContext
 import paige.navic.LocalNavStack
+import paige.navic.LocalPlatformContext
 import paige.navic.data.models.Screen
 import paige.navic.icons.Icons
 import paige.navic.icons.outlined.PlaylistRemove
@@ -32,6 +43,7 @@ import paige.navic.ui.screens.queue.components.QueueScreenItem
 import paige.navic.ui.screens.queue.viewmodels.QueueViewModel
 import paige.navic.utils.draggableItemsIndexed
 import paige.navic.utils.rememberDraggableListState
+import kotlin.time.DurationUnit
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -39,7 +51,7 @@ fun QueueScreen() {
 	val viewModel = koinViewModel<QueueViewModel>()
 	val platformContext = LocalPlatformContext.current
 	val backStack = LocalNavStack.current
-	val player = koinInject<MediaPlayerViewModel>()
+	val player = koinViewModel<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 	val isOnline by viewModel.isOnline.collectAsStateWithLifecycle()
 	val downloadedSongs by viewModel.downloadedSongs.collectAsStateWithLifecycle()
@@ -61,51 +73,106 @@ fun QueueScreen() {
 		}
 	}
 
-	LazyColumn(
-		modifier = Modifier
-			.padding(horizontal = 12.dp)
-			.fillMaxSize()
-			.clip(ContinuousRoundedRectangle(topStart = 16.dp, topEnd = 16.dp)),
-		state = draggableState.listState,
-		verticalArrangement = if (queue.isNotEmpty())
-			Arrangement.spacedBy(ListItemDefaults.SegmentedGap)
-		else Arrangement.Center
-	) {
-		draggableItemsIndexed(
-			state = draggableState,
-			items = queue,
-			key = { index, _ -> index }
-		) { index, song, isDragging ->
-			QueueScreenItem(
-				index = index,
-				count = queue.count(),
-				song = song,
-				isPlaying = playerState.currentIndex == index
-					&& !playerState.isPaused,
-				isSelected = playerState.currentIndex == index,
-				isDragging = isDragging,
-				draggableState = draggableState,
-				onClick = {
-					platformContext.clickSound()
-					if (playerState.currentIndex != index) {
-						player.playAt(index)
-						backStack.remove(Screen.Queue)
-					}
-				},
-				onRemove = {
-					haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-					player.removeFromQueue(index)
-				},
-				isOffline = !isOnline,
-				isDownloaded = downloadedSongs.containsKey(song.id)
-			)
+	val totalDurationText = remember(queue) {
+		val totalSeconds = queue.sumOf { it.duration.toInt(DurationUnit.SECONDS) }
+
+		val hours = totalSeconds / 3600
+		val minutes = (totalSeconds % 3600) / 60
+		val seconds = totalSeconds % 60
+
+		buildString {
+			if (hours > 0) {
+				append("${hours}h ")
+			}
+
+			if (minutes > 0 || hours > 0) {
+				append("${minutes}m ")
+			}
+
+			append("${seconds}s")
 		}
-		if (queue.isEmpty()) {
-			item {
-				ContentUnavailable(
-					icon = Icons.Outlined.PlaylistRemove,
-					label = stringResource(Res.string.info_no_queue)
+	}
+
+	val songsText = pluralStringResource(
+		Res.plurals.count_songs,
+		queue.size,
+		queue.size
+	)
+
+	Column(
+		modifier = Modifier
+			.fillMaxSize()
+			.clip(ContinuousRoundedRectangle(topStart = 16.dp, topEnd = 16.dp))
+	) {
+		if (queue.isNotEmpty()) {
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(horizontal = 24.dp, vertical = 8.dp),
+				horizontalArrangement = Arrangement.SpaceBetween,
+				verticalAlignment = Alignment.CenterVertically
+			) {
+				Text(
+					text = "$songsText • $totalDurationText",
+					style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+					color = MaterialTheme.colorScheme.onSurfaceVariant
 				)
+				TextButton(
+					onClick = {
+						haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+						player.clearQueue()
+					}
+				) {
+					Text(stringResource(Res.string.action_clear_queue))
+				}
+			}
+		}
+
+		LazyColumn(
+			modifier = Modifier
+				.padding(horizontal = 12.dp)
+				.fillMaxSize(),
+			state = draggableState.listState,
+			verticalArrangement = if (queue.isNotEmpty())
+				Arrangement.spacedBy(ListItemDefaults.SegmentedGap)
+			else Arrangement.Center
+		) {
+			draggableItemsIndexed(
+				state = draggableState,
+				items = queue,
+				key = { index, _ -> index }
+			) { index, song, isDragging ->
+				QueueScreenItem(
+					index = index,
+					count = queue.count(),
+					song = song,
+					isPlaying = playerState.currentIndex == index
+						&& !playerState.isPaused,
+					isSelected = playerState.currentIndex == index,
+					isDragging = isDragging,
+					draggableState = draggableState,
+					onClick = {
+						platformContext.clickSound()
+						if (playerState.currentIndex != index) {
+							player.playAt(index)
+							backStack.remove(Screen.Queue)
+						}
+					},
+					onRemove = {
+						haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+						player.removeFromQueue(index)
+					},
+					isOffline = !isOnline,
+					isDownloaded = downloadedSongs.containsKey(song.id)
+				)
+			}
+			if (queue.isEmpty()) {
+				item {
+					ContentUnavailable(
+						icon = Icons.Outlined.PlaylistRemove,
+						label = stringResource(Res.string.info_no_queue)
+					)
+				}
 			}
 		}
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/queue/QueueScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/queue/QueueScreen.kt
@@ -31,6 +31,7 @@ import navic.composeapp.generated.resources.count_songs
 import navic.composeapp.generated.resources.info_no_queue
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import paige.navic.LocalNavStack
 import paige.navic.LocalPlatformContext
@@ -51,7 +52,7 @@ fun QueueScreen() {
 	val viewModel = koinViewModel<QueueViewModel>()
 	val platformContext = LocalPlatformContext.current
 	val backStack = LocalNavStack.current
-	val player = koinViewModel<MediaPlayerViewModel>()
+	val player = koinInject<MediaPlayerViewModel>()
 	val playerState by player.uiState.collectAsStateWithLifecycle()
 	val isOnline by viewModel.isOnline.collectAsStateWithLifecycle()
 	val downloadedSongs by viewModel.downloadedSongs.collectAsStateWithLifecycle()


### PR DESCRIPTION
Bringed back queue info and changed top songs taken from 10 to 12 to not have a lone element.