### PR TITLE
fix: search bar font

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/search/components/TopBar.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/search/components/TopBar.kt
@@ -36,6 +36,7 @@ import paige.navic.LocalNavStack
 import paige.navic.icons.Icons
 import paige.navic.icons.outlined.ArrowBack
 import paige.navic.icons.outlined.Close
+import paige.navic.ui.theme.defaultFont
 
 @Composable
 fun SearchScreenTopBar(
@@ -91,7 +92,7 @@ fun SearchScreenTopBar(
 					onSearch(query.text.toString())
 				}
 			},
-			textStyle = TextStyle(color = MaterialTheme.colorScheme.onSurface),
+			textStyle = TextStyle(color = MaterialTheme.colorScheme.onSurface, fontFamily = defaultFont()),
 			cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
 			decorator = { innerTextField ->
 				Box(contentAlignment = Alignment.CenterStart) {


### PR DESCRIPTION
closes #363 

before/after
<img width="1080" height="281" alt="Screenshot_20260527-111659_Navic" src="https://github.com/user-attachments/assets/6690d691-4665-4ce5-b4d9-f8309c08db79" />
<img width="1080" height="293" alt="Screenshot_20260527-111716_Navic (Dev)" src="https://github.com/user-attachments/assets/0c44f653-42f5-4372-8a6d-7f6d3abaa380" />

