### PR TITLE
fix: playNext logic in album/playlists + show warning also on swipe

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRow.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRow.kt
@@ -25,7 +25,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,6 +62,7 @@ import paige.navic.shared.MediaPlayerViewModel
 import paige.navic.ui.components.common.CoverArt
 import paige.navic.ui.components.common.MarqueeText
 import paige.navic.ui.components.common.Waveform
+import paige.navic.ui.components.dialogs.QueueDuplicateDialog
 import paige.navic.util.core.InlineExplicitIcon
 import paige.navic.util.ui.segmentedShapes
 import paige.navic.util.core.toHoursMinutesSeconds
@@ -88,6 +92,8 @@ fun CollectionDetailScreenSongRow(
 	val dismissState = rememberSwipeToDismissBoxState()
 	val scope = rememberCoroutineScope()
 
+	var isPlayNextPending by rememberSaveable { mutableStateOf<Boolean?>(null) }
+
 	val itemShape = segmentedShapes(
 		index = index,
 		count = count,
@@ -98,8 +104,20 @@ fun CollectionDetailScreenSongRow(
 		modifier = Modifier.padding(horizontal = 16.dp, vertical = 1.5.dp),
 		state = dismissState,
 		onDismiss = {
-			if (it == SwipeToDismissBoxValue.StartToEnd) onAddToQueue()
-			if (it == SwipeToDismissBoxValue.EndToStart) onPlayNext()
+			if (it == SwipeToDismissBoxValue.StartToEnd) {
+				if (playerState.queue.any { item -> item.id == song.id }) {
+					isPlayNextPending = false
+				} else {
+					onAddToQueue()
+				}
+			}
+			if (it == SwipeToDismissBoxValue.EndToStart) {
+				if (playerState.queue.any { item -> item.id == song.id }) {
+					isPlayNextPending = true
+				} else {
+					onPlayNext()
+				}
+			}
 			scope.launch { dismissState.reset() }
 		},
 		backgroundContent = {
@@ -141,13 +159,13 @@ fun CollectionDetailScreenSongRow(
 				containerColor = MaterialTheme.colorScheme.surfaceContainer
 			),
 			leadingContent = {
-				if (isPlaylist) 
-						CoverArt(
-							modifier = Modifier.size(48.dp),
-							coverArtId = song.coverArtId,
-							shape = MaterialTheme.shapes.small
-						)
-				else 
+				if (isPlaylist)
+					CoverArt(
+						modifier = Modifier.size(48.dp),
+						coverArtId = song.coverArtId,
+						shape = MaterialTheme.shapes.small
+					)
+				else
 					Text(
 						text = "${index + 1}",
 						modifier = Modifier.width(25.dp),
@@ -247,6 +265,16 @@ fun CollectionDetailScreenSongRow(
 						)
 					}
 				}
+			}
+		)
+	}
+
+	if (isPlayNextPending != null) {
+		QueueDuplicateDialog(
+			onDismissRequest = { isPlayNextPending = null },
+			onConfirm = {
+				if (isPlayNextPending == true) onPlayNext() else onAddToQueue()
+				isPlayNextPending = null
 			}
 		)
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRowDropdown.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/collection/components/SongRowDropdown.kt
@@ -43,7 +43,8 @@ fun CollectionDetailScreenSongRowDropdown(
 	val player = koinInject<MediaPlayerViewModel>()
 	val backStack = LocalNavStack.current
 	var playlistDialogShown by rememberSaveable { mutableStateOf(false) }
-	var duplicateQueueDialogShown by rememberSaveable { mutableStateOf(false) }
+
+	var isPlayNextPending by rememberSaveable { mutableStateOf<Boolean?>(null) }
 
 	if (expanded) {
 		SongSheet(
@@ -57,14 +58,14 @@ fun CollectionDetailScreenSongRowDropdown(
 			onShare = onShare,
 			onPlayNext = {
 				if (player.uiState.value.queue.any { it.id == song.id }) {
-					duplicateQueueDialogShown = true
+					isPlayNextPending = true
 				} else {
 					onPlayNext()
 				}
 			},
 			onAddToQueue = {
 				if (player.uiState.value.queue.any { it.id == song.id }) {
-					duplicateQueueDialogShown = true
+					isPlayNextPending = false
 				} else {
 					onAddToQueue()
 				}
@@ -108,14 +109,15 @@ fun CollectionDetailScreenSongRowDropdown(
 		)
 	}
 
-	if (duplicateQueueDialogShown) {
+	if (isPlayNextPending != null) {
 		QueueDuplicateDialog(
 			onDismissRequest = {
-				duplicateQueueDialogShown = false
+				isPlayNextPending = null
 				onDismissRequest()
 			},
 			onConfirm = {
-				onAddToQueue()
+				if (isPlayNextPending == true) onPlayNext() else onAddToQueue()
+				isPlayNextPending = null
 			}
 		)
 	}


### PR DESCRIPTION
The warning would always defaut to add to Queue.
I added playNext logic to the dialog and shown the dialog also on swipe to add to queue/play next.

Closes #384.