### PR TITLE
patch SessionManager. Solve the connection issue under Wireguard VPN.

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -114,4 +114,5 @@ dependencies {
 	implementation(libs.bundles.glance)
 	implementation(libs.bundles.coil)
 	implementation(libs.bundles.media3)
+	implementation("io.ktor:ktor-client-okhttp:3.5.0")
 }

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/manager/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/manager/SessionManager.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.header
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import io.ktor.client.engine.okhttp.*
 
 class SessionManager(
 	private val settings: Settings,
@@ -33,13 +34,14 @@ class SessionManager(
 		instanceUrl: String,
 		username: String,
 		password: String,
-	) = SubsonicClient.Companion(
+	) = SubsonicClient(
 		baseUrl = instanceUrl,
 		auth = SubsonicAuth.Token(
 			username = username,
 			password = password,
 		),
 		client = "Navic",
+		engine = OkHttp.create(),
 		clientConfig = {
 			install(UserAgent) {
 				agent = "Navic"


### PR DESCRIPTION
The android application can't connect to the server under the following conditions : 
- server and client are on the same wireguard network (VPN).
- Navic app has been added to "allowed app" in wireguard configuration.

The reason is related to the use of Ktor's default engine network stack.

The patch change the KTor HTTP engine to "OkHTTP". 
It works