### PR TITLE
fix: Improve lrclib lyrics fetching

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/models/lyrics/LyricsConfig.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/models/lyrics/LyricsConfig.kt
@@ -17,7 +17,7 @@ data class LyricsConfig(
 		"https://lyricsplus-seven.vercel.app",
 		"https://lyricsplus.prjktla.workers.dev"
 	),
-	val lrcLibBaseUrl: String = "https://lrclib.net/api/get"
+	val lrcLibBaseUrl: String = "https://lrclib.net/api/search"
 ) {
 	companion object {
 		const val KEY = "lyrics_config_prefs"

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/repositories/LyricsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/repositories/LyricsRepository.kt
@@ -14,6 +14,11 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import paige.navic.data.database.dao.LyricDao
 import paige.navic.data.database.entities.LyricEntity
 import paige.navic.domain.manager.SessionManager
@@ -40,6 +45,13 @@ class LyricsRepository(
 		}
 	}
 	private val json = Json { ignoreUnknownKeys = true }
+
+	// regex for finding parenthesis as they are often for crediting producers which can make lrclib
+	// miss a search. example "songTitle (prod. producer123)"
+	private companion object {
+		val PARENTHETICAL = Regex("""\([^)]*\)""")
+		val REPEATED_WHITESPACE = Regex("""\s+""")
+	}
 
 	private fun getConfig(): LyricsConfig {
 		val raw = settings.getStringOrNull(LyricsConfig.KEY)
@@ -142,17 +154,25 @@ class LyricsRepository(
 	private suspend fun fetchRawLrcLib(song: DomainSong, config: LyricsConfig): String? {
 		return try {
 			val response = client.get(config.lrcLibBaseUrl) {
-				parameter("track_name", song.title)
-				parameter("artist_name", song.artistName)
-				parameter("album_name", song.albumTitle)
-				parameter("duration", song.duration.inWholeSeconds)
+				// using /api/search with q param to search for lyrics more loosely, finds lyrics
+				// more consistently because of how one may tag their music. Also looking at how i.e
+				// navidrome tags albumless songs with [Unknown Album] which will never find a result
+				parameter("q", "${song.title.withoutParentheticals()} ${song.artistName}")
 				accept(ContentType.Application.Json)
 			}
-			if (response.status.isSuccess()) {
-				response.bodyAsText()
-			} else {
+			if (!response.status.isSuccess()) {
 				throw Exception("unsuccessful status code ${response.status.value}")
 			}
+
+			// lrclib returns up to 20 results in the form of a json object, select the first one
+			// with synced lyrics, or first one with unsynced lyrics if none have any synced. Better
+			// matching can be added further to then look for songs that do have a similar album or
+			// duration though first result should be fine?
+			val results = json.parseToJsonElement(response.bodyAsText()).jsonArray
+			val match = results.firstOrNull { it.lyricsOrNull("syncedLyrics") != null }
+				?: results.firstOrNull { it.lyricsOrNull("plainLyrics") != null }
+
+			match?.toString()
 		} catch (ex: Exception) {
 			Logger.w(
 				"LyricsRepository",
@@ -162,6 +182,16 @@ class LyricsRepository(
 			null
 		}
 	}
+
+	private fun JsonElement.lyricsOrNull(key: String): String? =
+		jsonObject[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+
+	// remove parts of song title as defined by regex PARENTHETICAL
+	private fun String.withoutParentheticals(): String =
+		replace(PARENTHETICAL, " ")
+			.replace(REPEATED_WHITESPACE, " ")
+			.trim()
+			.ifEmpty { this }
 
 	private suspend fun fetchRawLyricsPlus(song: DomainSong, config: LyricsConfig): String? =
 		coroutineScope {


### PR DESCRIPTION
Using /api/get requires all parameters to be very exact for it to find any results but songs aren't always tagged 100% the same as they are stored on lrclib, I myself go through the effort of tagging my music as best I can but Navidrome sets the tag of albumless songs to [Unknow Album] for example, which will never find a match on lrclib. It's better to use /api/search with only the q param to search for lyrics more loosely only using the song name + artist name and then filtering those results out based on album or duration.