### PR TITLE
(Kinda) Android Auto support

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -75,10 +75,12 @@
 			android:name="paige.navic.shared.PlaybackService"
 			android:enabled="true"
 			android:exported="true"
-			android:foregroundServiceType="mediaPlayback"
-			android:permission="${applicationId}.permission.PLAYBACK_SERVICE">
+			android:foregroundServiceType="mediaPlayback">
+<!--			android:permission="${applicationId}.permission.PLAYBACK_SERVICE">   : Blocks android auto from seeing the app at all? -->
 			<intent-filter>
+
 				<action android:name="androidx.media3.session.MediaSessionService" />
+				<action android:name="android.media.browse.MediaBrowserService" />
 			</intent-filter>
 		</service>
 
@@ -129,5 +131,11 @@
 				android:resource="@xml/file_paths" />
 		</provider>
 
+		<!-- Android Auto -->
+		<meta-data android:name="com.google.android.gms.car.application"
+			android:resource="@xml/automotive_app_desc"/>
+		<meta-data
+			android:name="androidx.car.app.TintableAttributionIcon"
+			android:resource="@drawable/ic_navic" />
 	</application>
 </manifest>

--- a/androidApp/src/main/res/xml/automotive_app_desc.xml
+++ b/androidApp/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<automotiveApp>
+	<uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
So with this, the app shows up in android auto and can play music, controls all work. However, it cant see anything from the library, where it just says "No items", because AA relies on callbacks from ``MediaLibraryService`` (which is just a subclass of ``MediaSessionService`` so it shouldn't be *that* much of a issue to change and add?) to read the library items.

Also, the playback service permission also just blocks the app from being detected, so the simple fix was just to remove that line, tho i would guess there's probably a better way.



<sub> :3 </sub>