### PR TITLE
Support external equalizer apps via audio effect session broadcast + equaliser mode setting

### DIFF
--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.media.audiofx.AudioEffect
 import android.media.audiofx.Equalizer
 import android.net.Uri
 import android.os.Bundle
@@ -94,6 +95,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 	private val equaliserManager: EqualiserManager by inject()
 
 	private var equaliser: Equalizer? = null
+	private var audioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
 
 	override fun onCreate() {
 		super.onCreate()
@@ -179,6 +181,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			.build()
 
 		makeEqualiser(player.audioSessionId)
+		openAudioEffectSession(player.audioSessionId)
 
 		player.addListener(object : Player.Listener {
 			override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
@@ -190,7 +193,9 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			}
 
 			override fun onAudioSessionIdChanged(audioSessionId: Int) {
-				makeEqualiser(player.audioSessionId)
+				closeAudioEffectSession(audioEffectSessionId)
+				makeEqualiser(audioSessionId)
+				openAudioEffectSession(audioSessionId)
 			}
 		})
 
@@ -210,6 +215,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 	}
 
 	override fun onDestroy() {
+		closeAudioEffectSession(audioEffectSessionId)
 		equaliser?.release()
 		equaliser = null
 		scrobbleManager?.release()
@@ -264,6 +270,31 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 
 			return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
 		}
+	}
+
+	// Announces our audio session to the system so external equalizer apps can attach effects to it
+	private fun openAudioEffectSession(sessionId: Int) {
+		if (sessionId == C.AUDIO_SESSION_ID_UNSET) return
+		audioEffectSessionId = sessionId
+		sendBroadcast(
+			Intent(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION).apply {
+				putExtra(AudioEffect.EXTRA_AUDIO_SESSION, sessionId)
+				putExtra(AudioEffect.EXTRA_PACKAGE_NAME, packageName)
+				putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
+			}
+		)
+	}
+
+	// Tells external equalizer apps our audio session is going away so they can release their effects
+	private fun closeAudioEffectSession(sessionId: Int) {
+		if (sessionId == C.AUDIO_SESSION_ID_UNSET) return
+		sendBroadcast(
+			Intent(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION).apply {
+				putExtra(AudioEffect.EXTRA_AUDIO_SESSION, sessionId)
+				putExtra(AudioEffect.EXTRA_PACKAGE_NAME, packageName)
+			}
+		)
+		audioEffectSessionId = C.AUDIO_SESSION_ID_UNSET
 	}
 
 	private fun makeEqualiser(sessionId: Int) {

--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -66,6 +66,7 @@ import paige.navic.domain.models.DomainExplicitStatus
 import paige.navic.domain.models.DomainRadio
 import paige.navic.domain.models.DomainSong
 import paige.navic.domain.models.DomainSongCollection
+import paige.navic.domain.models.settings.EqualiserMode
 import paige.navic.domain.models.settings.ReplayGainMode
 import paige.navic.domain.repositories.PlayerStateRepository
 import paige.navic.domain.repositories.SongRepository
@@ -96,6 +97,8 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 
 	private var equaliser: Equalizer? = null
 	private var audioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
+	private var currentAudioSessionId: Int = C.AUDIO_SESSION_ID_UNSET
+	private var equaliserMode: EqualiserMode = EqualiserMode.Disabled
 
 	override fun onCreate() {
 		super.onCreate()
@@ -180,8 +183,9 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			.setCustomLayout(makeButtons(player))
 			.build()
 
-		makeEqualiser(player.audioSessionId)
-		openAudioEffectSession(player.audioSessionId)
+		currentAudioSessionId = player.audioSessionId
+		equaliserMode = equaliserManager.config.value.mode
+		applyEqualiserMode(equaliserMode, currentAudioSessionId)
 
 		player.addListener(object : Player.Listener {
 			override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
@@ -193,15 +197,19 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			}
 
 			override fun onAudioSessionIdChanged(audioSessionId: Int) {
-				closeAudioEffectSession(audioEffectSessionId)
-				makeEqualiser(audioSessionId)
-				openAudioEffectSession(audioSessionId)
+				currentAudioSessionId = audioSessionId
+				applyEqualiserMode(equaliserMode, audioSessionId)
 			}
 		})
 
 		scope.launch(Dispatchers.Main) {
-			equaliserManager.config.collect {
-				updateEqualiser()
+			equaliserManager.config.collect { config ->
+				if (config.mode != equaliserMode) {
+					equaliserMode = config.mode
+					applyEqualiserMode(equaliserMode, currentAudioSessionId)
+				} else {
+					updateEqualiser()
+				}
 			}
 		}
 	}
@@ -216,8 +224,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 
 	override fun onDestroy() {
 		closeAudioEffectSession(audioEffectSessionId)
-		equaliser?.release()
-		equaliser = null
+		releaseEqualiser()
 		scrobbleManager?.release()
 		serviceScope.cancel()
 		stopForeground(STOP_FOREGROUND_REMOVE)
@@ -272,6 +279,23 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 		}
 	}
 
+	// Applies the chosen equaliser mode
+	private fun applyEqualiserMode(mode: EqualiserMode, sessionId: Int) {
+		closeAudioEffectSession(audioEffectSessionId)
+		releaseEqualiser()
+
+		when (mode) {
+			EqualiserMode.BuiltIn -> makeEqualiser(sessionId)
+			EqualiserMode.External -> openAudioEffectSession(sessionId)
+			EqualiserMode.Disabled -> Unit
+		}
+	}
+
+	private fun releaseEqualiser() {
+		equaliser?.release()
+		equaliser = null
+	}
+
 	// Announces our audio session to the system so external equalizer apps can attach effects to it
 	private fun openAudioEffectSession(sessionId: Int) {
 		if (sessionId == C.AUDIO_SESSION_ID_UNSET) return
@@ -298,7 +322,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 	}
 
 	private fun makeEqualiser(sessionId: Int) {
-		equaliser?.release()
+		releaseEqualiser()
 		try {
 			val equaliser = Equalizer(0, sessionId).apply {
 				enabled = true

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -187,6 +187,10 @@
 	<string name="option_cover_art_action_disabled">Disabled</string>
 	<string name="option_cover_art_action_show_lyrics">Show lyrics</string>
 	<string name="option_equaliser">Equaliser</string>
+	<string name="option_equaliser_mode">Equaliser mode</string>
+	<string name="option_equaliser_mode_disabled">Disabled</string>
+	<string name="option_equaliser_mode_builtin">Built-in</string>
+	<string name="option_equaliser_mode_external">External</string>
 	<string name="option_list_view_mode">View mode</string>
 	<string name="option_list_view_mode_grid">Grid</string>
 	<string name="option_list_view_mode_list">List</string>
@@ -453,6 +457,7 @@
 	<string name="info_repeat_all">Repeat all</string>
 	<string name="info_app_icon">Changing the app icon will close Navic as Android requires this. Some icons may look identical on your home screen if your launcher dynamically themes the icon colours.</string>
 	<string name="info_equaliser_unsupported">Your device does not support this feature.</string>
+	<string name="info_equaliser_mode_not_builtin">Controls are only available in Built-in mode.</string>
 	<string name="info_lyric_provider_disclaimer">Enabling LRCLIB and/or LyricsPlus will make requests to external and unaffiliated web services.</string>
 
 	<string name="sideloading_warning_title">STOP, READ!</string>

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/models/settings/EqualiserConfig.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/models/settings/EqualiserConfig.kt
@@ -9,5 +9,6 @@ data class EqualiserConfig(
 	val bandLevels: Map<Int, Float> = emptyMap(),
 	val bandCount: Int = 0,
 	val bandLowerRange: Float = 0f,
-	val bandUpperRange: Float = 0f
+	val bandUpperRange: Float = 0f,
+	val mode: EqualiserMode = EqualiserMode.Disabled
 )

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/models/settings/EqualiserMode.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/models/settings/EqualiserMode.kt
@@ -1,0 +1,16 @@
+package paige.navic.domain.models.settings
+
+import kotlinx.serialization.Serializable
+import navic.composeapp.generated.resources.Res
+import navic.composeapp.generated.resources.option_equaliser_mode_builtin
+import navic.composeapp.generated.resources.option_equaliser_mode_disabled
+import navic.composeapp.generated.resources.option_equaliser_mode_external
+import org.jetbrains.compose.resources.StringResource
+
+// Which equaliser processes Navic's audio session. Builtin/External need to be mutually exclusive, 
+// otherwise they will fight for effect control and cause audio issues
+enum class EqualiserMode(val displayName: StringResource) {
+	Disabled(Res.string.option_equaliser_mode_disabled),
+	BuiltIn(Res.string.option_equaliser_mode_builtin),
+	External(Res.string.option_equaliser_mode_external)
+}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/settings/EqualiserScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/settings/EqualiserScreen.kt
@@ -25,19 +25,25 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_reset
+import navic.composeapp.generated.resources.info_equaliser_mode_not_builtin
 import navic.composeapp.generated.resources.info_equaliser_unsupported
 import navic.composeapp.generated.resources.option_equaliser
+import navic.composeapp.generated.resources.option_equaliser_mode
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import paige.navic.domain.manager.EqualiserManager
+import paige.navic.domain.models.settings.EqualiserMode
 import paige.navic.icons.Icons
 import paige.navic.icons.outlined.Refresh
+import paige.navic.ui.components.common.Form
 import paige.navic.ui.components.common.VerticalSlider
 import paige.navic.ui.components.layouts.NestedTopBar
 import paige.navic.ui.components.layouts.TopBarButton
+import paige.navic.ui.screens.settings.components.SettingSelectionRow
 
 @Composable
 fun SettingsEqualiserScreen() {
@@ -58,7 +64,7 @@ fun SettingsEqualiserScreen() {
 								)
 							}
 						},
-						enabled = config.bandLevels.isNotEmpty()
+						enabled = config.bandLevels.isNotEmpty() && config.mode == EqualiserMode.BuiltIn
 					) {
 						Icon(
 							imageVector = Icons.Outlined.Refresh,
@@ -80,6 +86,24 @@ fun SettingsEqualiserScreen() {
 					.padding(top = 16.dp, end = 16.dp, start = 16.dp),
 				horizontalAlignment = Alignment.CenterHorizontally
 			) {
+				Form(modifier = Modifier.widthIn(max = 600.dp)) {
+					SettingSelectionRow(
+						title = { Text(stringResource(Res.string.option_equaliser_mode)) },
+						items = EqualiserMode.entries.toImmutableList(),
+						label = { stringResource(it.displayName) },
+						selection = config.mode,
+						onSelect = { mode ->
+							scope.launch {
+								equaliserManager.setConfig(config.copy(mode = mode))
+							}
+						}
+					)
+				}
+
+				if (config.mode != EqualiserMode.BuiltIn) {
+					Text(stringResource(Res.string.info_equaliser_mode_not_builtin))
+					return@Column
+				}
 				if (config.bandCount == 0) {
 					Text(stringResource(Res.string.info_equaliser_unsupported))
 					return@Column


### PR DESCRIPTION
### Issue

External equalizer apps had no effect on Navic's playback, even though they worked fine for me with other music apps like Spotify. This has been raised in a previous issue, #404.

### Cause

Navic doesn't broadcast `AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION`. This is the Android mechanism which external apps discover another app's audio session by and attach their effects to. Media3 does not send it automatically.

### Fix

**1. Broadcast the audio effect control session**

`PlaybackService` now sends the open/close broadcasts with the required extras `EXTRA_AUDIO_SESSION`, `EXTRA_PACKAGE_NAME`, `EXTRA_CONTENT_TYPE` as required.

**2. Added an "Equaliser mode" setting**

Testing the broadcast fix made me realize a second issue. With the external equaliser attached, audio had loudness/effect inconsistency. Navic's internal equalizer (default settings) was still force-enabled on the same audio session, so two audio effects were being applied at once causing weird audio effects.

The fix makes the two "enabled" options mutually exclusive via a new setting (Settings > Playback > Equaliser), with three options:

- **Disabled** (default):  no internal EQ, no broadcast
- **Built-in**: Navic's in-app equaliser only
- **External**: no internal EQ, the session is broadcast for equalisers to modify

I mirrored the approach used by [Tempus](https://github.com/eddyizm/tempus), another Media3 based Subsonic client that solved the same conflict with the same three-way selector.

### Compatibility

Since the mode option is new, everyone will be set to **Disabled** after updating. Users who had custom equalizer settings will need to switch their mode to **Built-in** to have them applied again.

### Tests

Verified all 3 modes on my Android 17 device with an external equalizer app, they functioned as expected.

### UI Screenshots
<img width="302" height="642" alt="Screenshot_20260812-201829" src="https://github.com/user-attachments/assets/137ac1d0-dd3a-46a9-ac4f-a1fd055335ad" />
<img width="302" height="642" alt="Screenshot_20260812-201809" src="https://github.com/user-attachments/assets/46a0ef98-c795-4568-a086-17ba5934e853" />
<img width="302" height="642" alt="Screenshot_20260812-201748" src="https://github.com/user-attachments/assets/0a8863f4-b689-49fd-aeb0-b9ba299db8a8" />
<img width="302" height="642" alt="Screenshot_20260812-202239" src="https://github.com/user-attachments/assets/ddd52297-284d-4158-92fc-037c8bcc0261" />
